### PR TITLE
Fix outstanding linter issues, add doc strings, bring it up to standard

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ def get_version(*file_paths):
     """
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
     version_file = open(filename).read()    # pylint: disable=open-builtin
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
+    version_match = re.search(r"^__version__ = [ub]?['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError('Unable to find version string.')

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -4,6 +4,6 @@ Framework for Messaging.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 default_app_config = 'edx_ace.apps.EdxAceConfig'

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -1,9 +1,6 @@
-"""
-Framework for Messaging.
-"""
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
 
-from __future__ import absolute_import, unicode_literals
+__version__ = u'0.1.2'
 
-__version__ = '0.1.2'
-
-default_app_config = 'edx_ace.apps.EdxAceConfig'
+default_app_config = u'edx_ace.apps.EdxAceConfig'

--- a/edx_ace/ace.py
+++ b/edx_ace/ace.py
@@ -1,8 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 from edx_ace import delivery, policy, presentation
 from edx_ace.errors import ChannelError
 
 
 def send(msg):
+    u"""
+    Send a message to a recipient.
+
+    Calling this method will result in an attempt being made to deliver the provided message to the recipient. Depending
+    on the configured policies, it may be transmitted to them over one or more channels (email, sms, push etc).
+
+    The message must have valid values for all required fields in order for it to be sent. Different channels have
+    different requirements, so care must be taken to ensure that all of the needed information is present in the message
+    before calling ``ace.send()``.
+
+    Args:
+        msg (Message): The message to send.
+    """
     msg.report_basics()
 
     channels_for_message = policy.channels_for(msg)

--- a/edx_ace/apps.py
+++ b/edx_ace/apps.py
@@ -1,19 +1,15 @@
 # -*- coding: utf-8 -*-
-"""
-edx_ace Django application initialization.
-"""
-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, division, print_function
 
 from django.apps import AppConfig
 
 
 class EdxAceConfig(AppConfig):
-    """
+    u"""
     Configuration for the edx_ace Django application.
     """
 
-    name = 'edx_ace'
+    name = u'edx_ace'
 
     def ready(self):
         # noinspection PyUnresolvedReferences

--- a/edx_ace/channel/__init__.py
+++ b/edx_ace/channel/__init__.py
@@ -1,6 +1,4 @@
-"""
-Channels deliver messages to users that have already passed through the presentation and policy steps.
-"""
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 
 import abc
@@ -13,20 +11,20 @@ from edx_ace.utils.once import once
 from edx_ace.utils.plugins import get_plugins
 
 # TODO(later): encapsulate the shared part of this namespace in the utils.plugin module
-CHANNEL_EXTENSION_NAMESPACE = 'openedx.ace.channel'
+CHANNEL_EXTENSION_NAMESPACE = u'openedx.ace.channel'
 
 
 class ChannelType(Enum):
-    """
+    u"""
     All supported communication channels.
     """
-    EMAIL = 'email'
-    PUSH = 'push'
+    EMAIL = u'email'
+    PUSH = u'push'
 
 
 @six.add_metaclass(abc.ABCMeta)
 class Channel(object):
-    """
+    u"""
     Channels deliver messages to users that have already passed through the presentation and policy steps.
 
     Examples include email messages, push notifications, or in-browser messages. Implementations of this abstract class
@@ -38,7 +36,7 @@ class Channel(object):
 
     @abc.abstractmethod
     def deliver(self, message, rendered_message):
-        """
+        u"""
         Transmit a rendered message to a recipient.
 
         Args:
@@ -51,7 +49,7 @@ class Channel(object):
 
 @once
 def channels():
-    """
+    u"""
     Gathers all available channels.
 
     Note that this function loads all available channels from entry points. It expects the Django setting
@@ -66,7 +64,7 @@ def channels():
     """
     plugins = get_plugins(
         namespace=CHANNEL_EXTENSION_NAMESPACE,
-        names=getattr(settings, 'ACE_ENABLED_CHANNELS', []),
+        names=getattr(settings, u'ACE_ENABLED_CHANNELS', []),
     )
 
     channel_map = {}
@@ -74,7 +72,7 @@ def channels():
         channel = extension.obj
         if channel.channel_type in channel_map:
             raise ValueError(
-                'Multiple plugins registered for the same channel: {first} and {second}'.format(
+                u'Multiple plugins registered for the same channel: {first} and {second}'.format(
                     first=channel_map[channel.channel_type].__class__.__name__,
                     second=channel.__class__.__name__,
                 )

--- a/edx_ace/delivery.py
+++ b/edx_ace/delivery.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 import logging
 import time
@@ -22,7 +25,7 @@ MAX_EXPIRATION_DELAY = 5 * 60
 
 
 def deliver(channel_type, rendered_message, message):
-    """
+    u"""
     Deliver a message via a particular channel.
 
     Args:
@@ -37,31 +40,31 @@ def deliver(channel_type, rendered_message, message):
     channel = channels().get(channel_type)
     if not channel:
         raise UnsupportedChannelError(
-            'No implementation for channel {channel_type} registered. Available channels are: {channels}'.format(
+            u'No implementation for channel {channel_type} registered. Available channels are: {channels}'.format(
                 channel_type=channel_type,
-                channels=', '.join(six.text_type(registered_channel_type) for registered_channel_type in channels())
+                channels=u', '.join(six.text_type(registered_channel_type) for registered_channel_type in channels())
             )
         )
     logger = message.get_message_specific_logger(LOG)
 
-    timeout_seconds = getattr(settings, 'ACE_DEFAULT_EXPIRATION_DELAY', 120)
+    timeout_seconds = getattr(settings, u'ACE_DEFAULT_EXPIRATION_DELAY', 120)
     start_time = get_current_time()
     default_expiration_time = start_time + datetime.timedelta(seconds=timeout_seconds)
     max_expiration_time = start_time + datetime.timedelta(seconds=MAX_EXPIRATION_DELAY)
     expiration_time = min(max_expiration_time, message.expiration_time or default_expiration_time)
 
     while get_current_time() < expiration_time:
-        logger.debug('Attempting delivery of message')
+        logger.debug(u'Attempting delivery of message')
         try:
             channel.deliver(message, rendered_message)
         except RecoverableChannelDeliveryError as delivery_error:
             num_seconds = (delivery_error.next_attempt_time - get_current_time()).total_seconds()
-            logger.debug('Encountered a recoverable delivery error.')
+            logger.debug(u'Encountered a recoverable delivery error.')
             if delivery_error.next_attempt_time > expiration_time:
-                logger.debug('Message will expire before delivery can be reattempted, aborting.')
+                logger.debug(u'Message will expire before delivery can be reattempted, aborting.')
                 break
             elif num_seconds > 0:
-                logger.debug('Sleeping for %d seconds.', num_seconds)
+                logger.debug(u'Sleeping for %d seconds.', num_seconds)
                 time.sleep(num_seconds)
                 message.report(u'delivery_retried', num_seconds)
         else:

--- a/edx_ace/errors.py
+++ b/edx_ace/errors.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
 
 # TODO(later): To prevent a monolith of exception classes here,
 #   we may want to declare Channel-related errors in the
@@ -5,23 +7,28 @@
 
 
 class ChannelError(Exception):
+    u"""Indicates something went wrong in a delivery channel."""
     pass
 
 
 class RecoverableChannelDeliveryError(ChannelError):
+    u"""An error occurred during channel delivery that is non-fatal. The caller should re-attempt at a later time."""
+
     def __init__(self, message, next_attempt_time):
         self.next_attempt_time = next_attempt_time
         super(RecoverableChannelDeliveryError, self).__init__(message)
 
 
 class FatalChannelDeliveryError(ChannelError):
+    u"""A fatal error occurred during channel delivery. Do not retry."""
     pass
 
 
 class UnsupportedChannelError(ChannelError):
-    """ Raised when an attempt is made to process a message for an unsupported channel. """
+    u"""Raised when an attempt is made to process a message for an unsupported channel."""
     pass
 
 
 class InvalidMessageError(Exception):
+    u"""Encountered a message that cannot be sent due to missing or inconsistent information."""
     pass

--- a/edx_ace/message.py
+++ b/edx_ace/message.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
 
 import logging
 from abc import ABCMeta
@@ -15,8 +17,8 @@ from edx_ace.serialization import MessageAttributeSerializationMixin
 
 
 @attr.s
+@six.add_metaclass(ABCMeta)
 class Message(MessageAttributeSerializationMixin):
-    __metaclass__ = ABCMeta
 
     # mandatory attributes
     # Name is the unique identifier for the message type.
@@ -59,18 +61,18 @@ class Message(MessageAttributeSerializationMixin):
 
     @property
     def unique_name(self):
-        return '.'.join([self.app_label, self.name])
+        return u'.'.join([self.app_label, self.name])
 
     @property
     def log_id(self):
-        return '.'.join([
+        return u'.'.join([
             self.unique_name,
-            six.text_type(self.send_uuid) if self.send_uuid else 'no_send_uuid',
+            six.text_type(self.send_uuid) if self.send_uuid else u'no_send_uuid',
             six.text_type(self.uuid)
         ])
 
     def get_message_specific_logger(self, logger):
-        return MessageLoggingAdapter(logger, {'message': self})
+        return MessageLoggingAdapter(logger, {u'message': self})
 
     def report_basics(self):
         monitoring_report(u'message_name', self.unique_name)
@@ -82,7 +84,7 @@ class Message(MessageAttributeSerializationMixin):
 
 class MessageLoggingAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
-        return '[%s] %s' % (self.extra['message'].log_id, msg), kwargs
+        return u'[%s] %s' % (self.extra[u'message'].log_id, msg), kwargs
 
 
 @attr.s(cmp=False)

--- a/edx_ace/utils/date.py
+++ b/edx_ace/utils/date.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
 
 from datetime import datetime
 
@@ -6,21 +8,40 @@ from dateutil.tz import tzutc
 
 
 def get_current_time():
+    u"""The current time in the UTC timezone as a timezone-aware datetime object."""
     return datetime.now(tzutc())
 
 
-def serialize(obj):
+def serialize(timestamp_obj):
+    u"""
+    Serialize a datetime object to an ISO8601 formatted string.
+
+    Args:
+        timestamp_obj (datetime): The timestamp to serialize.
+
+    Returns:
+        basestring: A string representation of the timestamp in ISO8601 format.
+    """
     # TODO(later): my understanding is that type checks like this are not pythonic.
-    assert isinstance(obj, datetime)
+    assert isinstance(timestamp_obj, datetime)
 
     # TODO(later): what if utcoffset() returns 0?
-    if obj.tzinfo is not None and obj.utcoffset() is None:
-        return obj.isoformat() + 'Z'
+    if timestamp_obj.tzinfo is not None and timestamp_obj.utcoffset() is None:
+        return timestamp_obj.isoformat() + u'Z'
     else:
-        return obj.isoformat()
+        return timestamp_obj.isoformat()
 
 
-def deserialize(value):
-    if value is None:
+def deserialize(timestamp_iso8601_str):
+    u"""
+    Deserialize a datetime object from an ISO8601 formatted string.
+
+    Args:
+        timestamp_iso8601_str (basestring): A timestamp as an ISO8601 formatted string.
+
+    Returns:
+        datetime: A timezone-aware python datetime object.
+    """
+    if timestamp_iso8601_str is None:
         return None
-    return parse(value, yearfirst=True)
+    return parse(timestamp_iso8601_str, yearfirst=True)

--- a/edx_ace/utils/once.py
+++ b/edx_ace/utils/once.py
@@ -1,10 +1,61 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import functools
 
 
 def once(fn):
+    u"""
+    Decorates a function that will be called exactly once.
+
+    After the function is called once, its result is stored in memory and immediately returned to subsequent callers
+    instead of calling the decorated function again.
+
+    Examples:
+
+        An incrementing value::
+
+            _counter = 0
+
+            @once
+            def get_counter():
+                global _counter
+                _counter += 1
+                return _counter
+
+            def get_counter_updating():
+                global _counter
+                _counter += 1
+                return _counter
+
+            print(get_counter())  # This will print "0"
+            print(get_counter_updating()) # This will print "1"
+            print(get_counter())  # This will also print "0"
+            print(get_counter_updating()) # This will print "2"
+
+        Lazy loading::
+
+            @once
+            def load_config():
+                with open('config.json', 'r') as cfg_file:
+                    return json.load(cfg_file)
+
+            cfg = load_config()  # This will do the relatively expensive operation to
+                                 # read the file from disk.
+            cfg2 = load_config() # This call will not reload the file from disk, it
+                                 # will use the value returned by the first invocation
+                                 # of this function.
+
+    Args:
+        fn (callable): The function that should be called exactly once.
+
+    Returns:
+        callable: The wrapped function.
+    """
+
     @functools.wraps(fn)
     def wrapper():
-        if not hasattr(fn, '__once_result'):
+        if not hasattr(fn, u'__once_result'):
             fn.__once_result = fn()  # pylint: disable=protected-access
         return fn.__once_result  # pylint: disable=protected-access
 

--- a/edx_ace/utils/plugins.py
+++ b/edx_ace/utils/plugins.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import logging
 from functools import partial
 
@@ -7,6 +10,17 @@ LOG = logging.getLogger(__name__)
 
 
 def get_manager(namespace, names=None):
+    u"""
+    Get the stevedore extension manager for this namespace.
+
+    Args:
+        namespace (basestring): The entry point namespace to load plugins for.
+        names (list): A list of names to load. If this is ``None`` then all extension will be loaded from this
+            namespace.
+
+    Returns:
+        stevedore.enabled.EnabledExtensionManager: Extension manager with all extensions instantiated.
+    """
     return enabled.EnabledExtensionManager(
         namespace=namespace,
         check_func=partial(check_plugin, namespace=namespace, names=names),
@@ -15,13 +29,35 @@ def get_manager(namespace, names=None):
 
 
 def get_plugins(namespace, names=None):
+    u"""
+    Get all extensions for this namespace and list of names.
+
+    Args:
+        namespace (basestring): The entry point namespace to load plugins for.
+        names (list): A list of names to load. If this is ``None`` then all extension will be loaded from this
+            namespace.
+
+    Returns:
+        list: A list of extensions.
+    """
     return list(get_manager(namespace, names))
 
 
 def check_plugin(extension, namespace, names=None):
+    u"""
+    Check the extension to see if it's enabled.
+
+    Args:
+        extension (stevedore.extension.Extension): The extension to check.
+        namespace (basestring): The namespace that the extension was loaded from.
+        names (list): A whitelist of extensions that should be checked.
+
+    Returns:
+        bool: Whether or not this extension is enabled and should be used.
+    """
     if names is None or extension.name in names:
-        plugin_enabled = getattr(extension.plugin, 'enabled', True)
+        plugin_enabled = getattr(extension.plugin, u'enabled', True)
         if not plugin_enabled:
-            LOG.info('Extension with name %s for namespace %s is not enabled', extension.name, namespace)
+            LOG.info(u'Extension with name %s for namespace %s is not enabled', extension.name, namespace)
         return plugin_enabled
     return False

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_version(*file_paths):
     """
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
     version_file = open(filename).read()
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+    version_match = re.search(r"^__version__ = [ub]?['\"]([^'\"]*)['\"]",
                               version_file, re.M)
     if version_match:
         return version_match.group(1)


### PR DESCRIPTION
Stuff I'm doing in every file:

* Add the header that declares the encoding and the \_\_future__ imports
* Prepend all literal strings with "u"
* Ensure every function has a docstring (google style)
* Remove all lint-amnesty issues either by retaining the pylint disable bit or actually fixing the issue