### PR TITLE
WIP: create sailthru templates programmatically

### DIFF
--- a/edx_ace/channel/file.py
+++ b/edx_ace/channel/file.py
@@ -58,7 +58,7 @@ class FileEmailChannel(Channel):
     By default it writes the output file to /edx/src/ace_output.html and overwrites any existing file at that location.
     In the edX devstack, this folder is shared between the host and the containers so you can easily open the file using
     a browser on the host. You can override this output file location by passing in a ``output_file_path`` key in the
-    message context. That path specifies where in the container filesystem the file should be written.
+    message options. That path specifies where in the container filesystem the file should be written.
 
     Both streams of output are UTF-8 encoded.
     """
@@ -77,7 +77,7 @@ class FileEmailChannel(Channel):
         template_vars[u'email_address'] = message.recipient.email_address
 
         rendered_template = TEMPLATE.format(**template_vars)
-        output_file_path = message.context.get(PATH_OVERRIDE_KEY, DEFAULT_OUTPUT_FILE_PATH_TPL.format(
+        output_file_path = message.options.get(PATH_OVERRIDE_KEY, DEFAULT_OUTPUT_FILE_PATH_TPL.format(
             recipient=message.recipient,
             date=datetime.now()
         ))

--- a/edx_ace/message.py
+++ b/edx_ace/message.py
@@ -77,11 +77,16 @@ class Message(MessageAttributeSerializationMixin):
         validator=attr.validators.optional(attr.validators.instance_of(UUID)),
         default=None
     )
+    options = attr.ib()
     language = attr.ib(default=None)
     log_level = attr.ib(default=None)
 
     @context.default
     def default_context_value(self):
+        return {}
+
+    @options.default
+    def default_options_value(self):
         return {}
 
     @uuid.default
@@ -176,10 +181,15 @@ class MessageType(MessageAttributeSerializationMixin):
     )
     app_label = attr.ib()
     name = attr.ib()
+    options = attr.ib()
     log_level = attr.ib(default=None)
 
     @context.default
     def default_context_value(self):
+        return {}
+
+    @options.default
+    def default_options_value(self):
         return {}
 
     @uuid.default
@@ -227,6 +237,7 @@ class MessageType(MessageAttributeSerializationMixin):
             recipient=recipient,
             language=language,
             log_level=self.log_level,
+            options=self.options,
         )
 
     # We override these so that a subtype of MessageType can compare equal


### PR DESCRIPTION
@iloveagent57 here is a sketch of the kind of thing we were thinking in order to support "one template per message type".

This will automatically create a Sailthru template the first time a message comes through for a particular message type.

FYI @edx/rapid-experiments-team 