### PR TITLE
Add Django email channel

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Nimisha Asthagiri <nasthagiri@edx.org>
+Omar Al-Ithawi <i@omardo.com>

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -31,6 +31,15 @@ before they will function correctly.
     :language: python
     :dedent: 12
 
+:class:`~.DjangoEmailChannel` Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: /../edx_ace/channel/django_email.py
+    :start-after: .. settings_start
+    :end-before: .. settings_end
+    :language: python
+    :dedent: 12
+
 Create a message
 ----------------
 
@@ -66,6 +75,24 @@ using standard Django template resolution mechanisms.
 
 The specific templates needed for existing renderers are listed in :py:mod:`edx_ace.renderers`.
 
+Transactional messages
+----------------------
+
+Transactional messages such as password reset should be marked as ``options.transactional = True``,
+while not required, transactional messages are recommened to use the ``django_email`` channel which supports
+a custom ``options.from_address`` email.
+to ensure that it won't be subject to marketing messages opt-out policies, for example:
+
+.. code:: python
+
+    # myapp/messages.py
+
+    class PurchaseOrderComplete(edx_ace.message.MessageType):
+        def __init__(self, *args, **kwargs):
+            super(PurchaseOrderComplete, self).__init__(*args, **kwargs)
+
+            self.options['transactional'] = True
+            self.options['from_address'] = settings.ECOMMERCE_FROM_EMAIL
 
 Send a message
 --------------

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -35,6 +35,14 @@ edx\_ace\.channel\.sailthru
     :undoc-members:
     :show-inheritance:
 
+edx\_ace\.channel\.django_email
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: edx_ace.channel.django_email
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Exceptions
 ----------

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -15,7 +15,7 @@ from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 from .channel import ChannelType, Channel
 
-__version__ = u'0.1.6'
+__version__ = u'0.1.7'
 
 default_app_config = u'edx_ace.apps.EdxAceConfig'
 

--- a/edx_ace/channel/django_email.py
+++ b/edx_ace/channel/django_email.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+u"""
+:mod:`edx_ace.channel.django_email` implements a Django `send_mail()` email
+delivery channel for ACE.
+"""
+from __future__ import absolute_import, division, print_function
+
+import logging
+import re
+from smtplib import SMTPException
+
+from django.conf import settings
+from django.core import mail
+
+from edx_ace.channel import Channel, ChannelType
+from edx_ace.errors import FatalChannelDeliveryError
+
+LOG = logging.getLogger(__name__)
+
+TEMPLATE = u"""\
+<!DOCTYPE html>
+<html>
+    <head>
+        {head_html}
+    </head>
+    <body>
+        {body_html}
+    </body>
+</html>
+"""
+
+
+class DjangoEmailChannel(Channel):
+    u"""
+    A `send_mail()` channel for edX ACE.
+
+    This is both useful for providing an alternative to Sailthru and to debug ACE mail by
+    inspecting `django.core.mail.outbox`.
+    """
+
+    channel_type = ChannelType.EMAIL
+
+    @classmethod
+    def enabled(cls):
+        u"""
+        Returns: True always!
+        """
+        return True
+
+    def deliver(self, message, rendered_message):
+        # Compress spaces and remove newlines to make it easier to author templates.
+        subject = re.sub(u'\\s+', u' ', rendered_message.subject, re.UNICODE).strip()
+        default_from_address = getattr(settings, u'DEFAULT_FROM_EMAIL', None)
+        from_address = message.options.get(u'from_address', default_from_address)
+        if not from_address:
+            raise FatalChannelDeliveryError(
+                u'from_address must be included in message delivery options or as the DEFAULT_FROM_EMAIL settings'
+            )
+
+        rendered_template = TEMPLATE.format(
+            head_html=rendered_message.head_html,
+            body_html=rendered_message.body_html,
+        )
+
+        try:
+            mail.send_mail(
+                subject,
+                rendered_message.body,
+                from_address,
+                [message.recipient.email_address],
+                html_message=rendered_template,
+            )
+        except SMTPException as e:
+            LOG.exception(e)
+            raise FatalChannelDeliveryError(u'An SMTP error occurred (and logged) from Django send_email()')

--- a/edx_ace/channel/django_email.py
+++ b/edx_ace/channel/django_email.py
@@ -36,6 +36,26 @@ class DjangoEmailChannel(Channel):
 
     This is both useful for providing an alternative to Sailthru and to debug ACE mail by
     inspecting `django.core.mail.outbox`.
+
+
+
+    Example:
+
+        Sample settings::
+
+            .. settings_start
+            EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+            EMAIL_HOST = 'localhost'
+            DEFAULT_FROM_EMAIL = 'hello@example.org'
+
+            ACE_CHANNEL_DEFAULT_EMAIL = 'sailthru_email'
+            ACE_CHANNEL_TRANSACTIONAL_EMAIL = 'django_email'
+
+            ACE_ENABLED_CHANNELS = [
+                'sailthru_email',
+                'django_email',
+            ]
+            .. settings_end
     """
 
     channel_type = ChannelType.EMAIL

--- a/edx_ace/channel/sailthru.py
+++ b/edx_ace/channel/sailthru.py
@@ -10,6 +10,7 @@ import random
 import textwrap
 from datetime import datetime, timedelta
 from enum import Enum
+from gettext import gettext as _
 
 import attr
 import six
@@ -148,6 +149,20 @@ class SailthruEmailChannel(Channel):
             hasattr(settings, required_setting)
             for required_setting in required_settings
         )
+
+    @property
+    def action_links(self):
+        # Note that these variables are evaluated by Sailthru, not the Django template engine
+        return [
+            (u'{view_url}', _(u'View on Web')),
+            (u'{optout_confirm_url}', _(u'Unsubscribe from this list')),
+        ]
+
+    @property
+    def tracker_image_sources(self):
+        # Note {beacon_src} is not a template variable that is evaluated by the Django template engine.
+        # It is evaluated by Sailthru when the email is sent.
+        return [u'{beacon_src}']
 
     def __init__(self):
         if not self.enabled():

--- a/edx_ace/delivery.py
+++ b/edx_ace/delivery.py
@@ -10,12 +10,9 @@ import datetime
 import logging
 import time
 
-import six
-
 from django.conf import settings
 
-from edx_ace.channel import channels
-from edx_ace.errors import RecoverableChannelDeliveryError, UnsupportedChannelError
+from edx_ace.errors import RecoverableChannelDeliveryError
 from edx_ace.utils.date import get_current_time
 
 LOG = logging.getLogger(__name__)
@@ -29,12 +26,12 @@ LOG = logging.getLogger(__name__)
 MAX_EXPIRATION_DELAY = 5 * 60
 
 
-def deliver(channel_type, rendered_message, message):
+def deliver(channel, rendered_message, message):
     u"""
     Deliver a message via a particular channel.
 
     Args:
-        channel_type (ChannelType): The channel type to deliver the channel over.
+        channel (Channel): The channel to deliver the message over.
         rendered_message (object): Each attribute of this object contains rendered content.
         message (Message): The message that is being sent.
 
@@ -42,15 +39,8 @@ def deliver(channel_type, rendered_message, message):
         :class:`.UnsupportedChannelError`: If no channel of the requested channel type is available.
 
     """
-    channel = channels().get(channel_type)
-    if not channel:
-        raise UnsupportedChannelError(
-            u'No implementation for channel {channel_type} registered. Available channels are: {channels}'.format(
-                channel_type=channel_type,
-                channels=u', '.join(six.text_type(registered_channel_type) for registered_channel_type in channels())
-            )
-        )
     logger = message.get_message_specific_logger(LOG)
+    channel_type = channel.channel_type
 
     timeout_seconds = getattr(settings, u'ACE_DEFAULT_EXPIRATION_DELAY', 120)
     start_time = get_current_time()

--- a/edx_ace/message.py
+++ b/edx_ace/message.py
@@ -77,11 +77,16 @@ class Message(MessageAttributeSerializationMixin):
         validator=attr.validators.optional(attr.validators.instance_of(UUID)),
         default=None
     )
+    options = attr.ib()
     language = attr.ib(default=None)
     log_level = attr.ib(default=None)
 
     @context.default
     def default_context_value(self):
+        return {}
+
+    @options.default
+    def default_options_value(self):
         return {}
 
     @uuid.default
@@ -176,11 +181,16 @@ class MessageType(MessageAttributeSerializationMixin):
     )
     app_label = attr.ib()
     name = attr.ib()
+    options = attr.ib()
     log_level = attr.ib(default=None)
 
     @context.default
     def default_context_value(self):
         return {}
+
+    @options.default
+    def default_options_value(self):
+        return {}  # pragma: no cover
 
     @uuid.default
     def generate_uuid(self):
@@ -227,6 +237,7 @@ class MessageType(MessageAttributeSerializationMixin):
             recipient=recipient,
             language=language,
             log_level=self.log_level,
+            options=self.options,
         )
 
     # We override these so that a subtype of MessageType can compare equal

--- a/edx_ace/presentation.py
+++ b/edx_ace/presentation.py
@@ -17,12 +17,12 @@ RENDERERS = {
 
 def render(channel, message):
     u""" Returns the rendered content for the given channel and message. """
-    renderer = RENDERERS.get(channel)
+    renderer = RENDERERS.get(channel.channel_type)
 
     if not renderer:
-        error_msg = u'No renderer is registered for the channel [{}].'.format(channel)
+        error_msg = u'No renderer is registered for the channel type [{}].'.format(channel.channel_type)
         raise errors.UnsupportedChannelError(error_msg)
 
     message_language = message.language or translation.get_language()
     with translation.override(message_language):
-        return renderer.render(message)
+        return renderer.render(channel, message)

--- a/edx_ace/renderers.py
+++ b/edx_ace/renderers.py
@@ -11,8 +11,6 @@ import attr
 
 from django.template import loader
 
-from edx_ace.channel import ChannelType
-
 
 class AbstractRenderer(object):
     u"""
@@ -22,15 +20,15 @@ class AbstractRenderer(object):
     and context, and outputting a rendered message for a specific message
     channel (e.g. email, SMS, push notification).
     """
-    channel = None
     rendered_message_cls = None
 
-    def render(self, message):
+    def render(self, channel, message):
         u"""
         Renders the given message.
 
         Args:
-             message (Message)
+             channel (:class:`Channel`): The channel to render the message for.
+             message (:class:`Message`): The message being rendered.
 
          Returns:
              dict: Mapping of template names/types to rendered text.
@@ -44,16 +42,17 @@ class AbstractRenderer(object):
                 filename = field.replace(u'_html', u'.html')
             else:
                 filename = field + u'.txt'
-            template = self.get_template_for_message(message, filename)
+            template = self.get_template_for_message(channel, message, filename)
             render_context = {
                 u'message': message,
+                u'channel': channel,
             }
             render_context.update(message.context)
             rendered[field] = template.render(render_context)
 
         return self.rendered_message_cls(**rendered)  # pylint: disable=not-callable
 
-    def get_template_for_message(self, message, filename):
+    def get_template_for_message(self, channel, message, filename):
         u"""
         Arguments:
             message (:class:`Message`): The message being rendered.
@@ -62,10 +61,10 @@ class AbstractRenderer(object):
         Returns:
             The full template path to the template to render.
         """
-        template_path = u'{app_label}/edx_ace/{name}/{channel}/{filename}'.format(
+        template_path = u'{app_label}/edx_ace/{name}/{channel_type}/{filename}'.format(
             app_label=message.app_label,
             name=message.name,
-            channel=self.channel.value,
+            channel_type=channel.channel_type.value,
             filename=filename,
         )
         return loader.get_template(template_path)
@@ -88,5 +87,4 @@ class EmailRenderer(AbstractRenderer):
     u"""
     A renderer for :attr:`.ChannelType.EMAIL` channels.
     """
-    channel = ChannelType.EMAIL
     rendered_message_cls = RenderedEmail

--- a/edx_ace/test_utils/__init__.py
+++ b/edx_ace/test_utils/__init__.py
@@ -34,21 +34,3 @@ def patch_policies(test_case, policies):
     )
     patcher.start()
     test_case.addCleanup(patcher.stop)
-
-
-def patch_channels(test_case, channels):
-    u"""
-    Set active channels for the duration of a test.
-
-    Arguments:
-        test_case (:class:`unittest.TestCase`): The test case that is running
-        channels: The set of active channels to return from :func:`edx_ace.delivery.channels`
-    """
-    patcher = patch(
-        u'edx_ace.delivery.channels',
-        return_value={
-            c.channel_type: c for c in channels
-        }
-    )
-    patcher.start()
-    test_case.addCleanup(patcher.stop)

--- a/edx_ace/tests/channel/test_channel_helpers.py
+++ b/edx_ace/tests/channel/test_channel_helpers.py
@@ -1,0 +1,67 @@
+u"""
+Tests of :mod:`edx_ace.channel`.
+"""
+from __future__ import absolute_import
+
+from mock import patch
+
+from django.test import TestCase, override_settings
+
+from edx_ace.channel import ChannelMap, ChannelType, get_channel_for_message
+from edx_ace.channel.file import FileEmailChannel
+from edx_ace.channel.sailthru import SailthruEmailChannel
+from edx_ace.errors import UnsupportedChannelError
+from edx_ace.message import Message
+from edx_ace.recipient import Recipient
+from edx_ace.utils.date import get_current_time
+
+
+class TestChannelMap(TestCase):
+    u"""
+    Tests for the channels().
+    """
+
+    def setUp(self):
+        self.msg_kwargs = {
+            u'app_label': u'test_app_label',
+            u'name': u'test_message',
+            u'expiration_time': get_current_time(),
+            u'context': {
+                u'key1': u'value1',
+                u'key2': u'value2',
+            },
+            u'recipient': Recipient(
+                username=u'me',
+            )
+        }
+
+    def test_get_channel_for_message(self):
+        channel_map = ChannelMap([
+            [u'file_email', FileEmailChannel],
+            [u'sailthru_email', SailthruEmailChannel],
+        ])
+
+        transactional_msg = Message(options={u'transactional': True}, **self.msg_kwargs)
+        info_msg = Message(options={}, **self.msg_kwargs)
+
+        with patch(u'edx_ace.channel.channels', return_value=channel_map):
+            assert get_channel_for_message(ChannelType.EMAIL, transactional_msg) is FileEmailChannel
+            assert get_channel_for_message(ChannelType.EMAIL, info_msg) is SailthruEmailChannel
+
+            with self.assertRaises(UnsupportedChannelError):
+                assert get_channel_for_message(ChannelType.PUSH, transactional_msg)
+
+    @override_settings(
+        ACE_CHANNEL_DEFAULT_EMAIL='sailthru_email',
+        ACE_CHANNEL_TRANSACTIONAL_EMAIL='file_email',
+    )
+    def test_default_channel(self):
+        channel_map = ChannelMap([
+            ['sailthru', SailthruEmailChannel],
+        ])
+
+        message = Message(options={u'transactional': True}, **self.msg_kwargs)
+
+        with patch(u'edx_ace.channel.channels', return_value=channel_map):
+            channel = get_channel_for_message(ChannelType.EMAIL, message)
+            assert channel is SailthruEmailChannel

--- a/edx_ace/tests/channel/test_django_email.py
+++ b/edx_ace/tests/channel/test_django_email.py
@@ -1,0 +1,111 @@
+# pylint: disable=missing-docstring
+from __future__ import absolute_import
+
+from smtplib import SMTPException
+
+from mock import Mock, patch
+
+from django.core import mail
+from django.test import TestCase, override_settings
+
+from edx_ace.channel.django_email import DjangoEmailChannel
+from edx_ace.errors import FatalChannelDeliveryError
+from edx_ace.message import Message
+from edx_ace.presentation import render
+from edx_ace.recipient import Recipient
+
+
+class TestDjangoEmailChannel(TestCase):
+    def setUp(self):
+        super(TestDjangoEmailChannel, self).setUp()
+
+        self.channel = DjangoEmailChannel()
+        self.message = Message(
+            app_label=u'testapp',
+            name=u'testmessage',
+            options={
+                u'from_address': u'bulk@example.com',
+            },
+            recipient=Recipient(username=u'Robot', email_address=u'mr@robot.io'),
+        )
+
+        self.mock_rendered_message = Mock(
+            subject=u'\n Hello from  \r\nRobot ! \n',
+            body=u'Just trying to see what is like to talk to a human!',
+            body_html=u"""
+                <p>Just trying to see what is like to talk to a human!</p>
+
+                <hr />
+            """,
+        )
+
+    def _get_rendered_message(self):
+        channel = DjangoEmailChannel()
+        message = Message(
+            app_label=u'testapp',
+            name=u'testmessage',
+            options={},
+            recipient=Recipient(username=u'Robot', email_address=u'mr@robot.io'),
+        )
+
+        return render(channel, message)
+
+    def test_enabled_method(self):
+        assert self.channel.enabled()
+
+    def test_happy_path(self):
+        self.channel.deliver(self.message, self.mock_rendered_message)
+
+        sent_email = mail.outbox[0]
+
+        assert sent_email.subject == u'Hello from Robot !'
+        assert u'Just trying to see what' in sent_email.body
+        assert sent_email.to == [u'mr@robot.io']
+
+        html_body, _ = sent_email.alternatives[0]
+
+        assert u'talk to a human!</p>' in html_body
+
+    @patch(u'django.core.mail.send_mail', side_effect=SMTPException)
+    def test_smtp_failure(self, _send_mail):
+        with self.assertRaises(FatalChannelDeliveryError):
+            self.channel.deliver(self.message, self.mock_rendered_message)
+
+    @override_settings(DEFAULT_FROM_EMAIL=None)
+    def test_with_no_from_address_without_default(self):
+        message = Message(
+            app_label=u'testapp',
+            name=u'testmessage',
+            options={},
+            recipient=Recipient(username=u'Robot', email_address=u'mr@robot.io'),
+        )
+
+        with self.assertRaises(FatalChannelDeliveryError):
+            self.channel.deliver(message, self.mock_rendered_message)
+
+    @override_settings(DEFAULT_FROM_EMAIL=u'hello@edx.org')
+    def test_with_no_from_address_with_default(self):
+        message = Message(
+            app_label=u'testapp',
+            name=u'testmessage',
+            options={},
+            recipient=Recipient(username=u'Robot', email_address=u'mr@robot.io'),
+        )
+
+        self.channel.deliver(message, self.mock_rendered_message)
+        assert len(mail.outbox) == 1, u'Should have one email'
+
+    def test_render_email_with_django_channel(self):
+        rendered_email = self._get_rendered_message()
+        assert u'{beacon_src}' not in rendered_email.body_html
+        assert u'{view_url}' not in rendered_email.body_html
+        assert u'{optout_confirm_url}' not in rendered_email.body_html
+
+    def test_happy_sending_rendered_email(self):
+        rendered_message = self._get_rendered_message()
+        self.channel.deliver(self.message, rendered_message)
+
+        assert mail.outbox, u'Should send the message'
+        html_email = mail.outbox[0].alternatives[0][0]
+        assert u'template head.html' in html_email
+        assert u'template body.html' in html_email

--- a/edx_ace/tests/channel/test_file_email.py
+++ b/edx_ace/tests/channel/test_file_email.py
@@ -1,0 +1,55 @@
+# pylint: disable=missing-docstring
+from __future__ import absolute_import
+
+from smtplib import SMTPException
+
+from mock import Mock, patch
+
+from django.core import mail
+from django.core.files.temp import NamedTemporaryFile
+from django.test import TestCase
+
+from edx_ace.channel.file import PATH_OVERRIDE_KEY, FileEmailChannel
+from edx_ace.errors import FatalChannelDeliveryError
+from edx_ace.message import Message
+from edx_ace.recipient import Recipient
+from edx_ace.renderers import RenderedEmail
+
+
+class TestFilesEmailChannel(TestCase):
+    def test_enabled_method(self):
+        channel = FileEmailChannel()
+        assert channel.enabled()
+
+    def test_happy_path(self):
+        channel = FileEmailChannel()
+        rendered_message = RenderedEmail(
+            from_name=u'Robot',
+            head_html=u'<img src="https://tracker/.img" />',
+            subject=u'\n Hello from  \r\nRobot ! \n',
+            body=u'Just trying to see what is like to talk to a human!',
+            body_html=u"""
+                <p>Just trying to see what is like to talk to a human!</p>
+
+                <hr />
+            """,
+        )
+
+        with NamedTemporaryFile('r+') as f:
+            message = Message(
+                app_label=u'testapp',
+                name=u'testmessage',
+                options={
+                    u'from_address': u'bulk@example.com',
+                    PATH_OVERRIDE_KEY: f.name,
+                },
+                recipient=Recipient(username=u'Robot', email_address=u'mr@robot.io'),
+            )
+
+            channel.deliver(message, rendered_message)
+
+            contents = f.read()
+            assert u'subject: Hello from' in contents
+            assert u'to: mr@robot.io' in contents
+            assert u'body: Just trying to see what' in contents
+            assert u'talk to a human!</p>' in contents

--- a/edx_ace/tests/channel/test_sailthru.py
+++ b/edx_ace/tests/channel/test_sailthru.py
@@ -1,0 +1,26 @@
+# pylint: disable=missing-docstring
+from __future__ import absolute_import
+
+from django.test import TestCase
+
+from edx_ace.channel.sailthru import SailthruEmailChannel
+from edx_ace.message import Message
+from edx_ace.presentation import render
+from edx_ace.recipient import Recipient
+
+
+class TestSailthruChannel(TestCase):
+    def test_render_email_with_sailthru(self):
+        channel = SailthruEmailChannel()
+        message = Message(
+            app_label=u'testapp',
+            name=u'testmessage',
+            options={},
+            recipient=Recipient(username=u'Robot', email_address=u'mr@robot.io'),
+        )
+
+        rendered_email = render(channel, message)
+
+        assert u'{beacon_src}' in rendered_email.body_html
+        assert u'{view_url}' in rendered_email.body_html
+        assert u'{optout_confirm_url}' in rendered_email.body_html

--- a/edx_ace/tests/test_date.py
+++ b/edx_ace/tests/test_date.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import
 from datetime import datetime
 from unittest import TestCase
 
-from hypothesis import strategies as st
 from hypothesis import example, given
+from hypothesis import strategies as st
 from hypothesis.extra.pytz import timezones
 
 from edx_ace.utils.date import deserialize, serialize

--- a/edx_ace/tests/test_message.py
+++ b/edx_ace/tests/test_message.py
@@ -9,8 +9,8 @@ from unittest import TestCase
 
 import ddt
 import six
-from hypothesis import strategies as st
 from hypothesis import given
+from hypothesis import strategies as st
 from hypothesis.extra.pytz import timezones
 from mock import patch
 

--- a/edx_ace/tests/test_message.py
+++ b/edx_ace/tests/test_message.py
@@ -60,10 +60,14 @@ class TestMessage(TestCase):
         }
 
     def test_basic(self):
-        message = Message(**self.msg_kwargs)
+        transactional_message = Message(options={u'transactional': True}, **self.msg_kwargs)
         for key in self.msg_kwargs:
-            self.assertEqual(getattr(message, key), self.msg_kwargs.get(key))
-        self.assertIsNotNone(message.uuid)
+            self.assertEqual(getattr(transactional_message, key), self.msg_kwargs.get(key))
+        self.assertIsNotNone(transactional_message.uuid)
+        assert transactional_message.options.get(u'transactional')  # pylint: disable=no-member
+
+        normal_message = Message(**self.msg_kwargs)
+        assert not dict(normal_message.options)
 
     def test_serialization(self):
         message = Message(**self.msg_kwargs)

--- a/edx_ace/tests/test_presentation.py
+++ b/edx_ace/tests/test_presentation.py
@@ -1,0 +1,28 @@
+u"""
+Tests of :mod:`edx_ace.presentation`.
+"""
+from __future__ import absolute_import
+
+from unittest import TestCase
+
+from mock import Mock
+
+from edx_ace.channel import ChannelType
+from edx_ace.errors import UnsupportedChannelError
+from edx_ace.presentation import render
+
+
+class TestRender(TestCase):
+    u"""
+    Tests for unsupported rendering for a channel.
+    """
+
+    def test_missing_renderer(self):
+        channel = Mock(
+            channel_type=ChannelType.PUSH,
+        )
+
+        message = Mock()
+
+        with self.assertRaises(UnsupportedChannelError):
+            render(channel, message)

--- a/edx_ace/tests/test_templates/README.md
+++ b/edx_ace/tests/test_templates/README.md
@@ -1,0 +1,2 @@
+# Test App Test Fixtures
+This is a dummy app withe templates for a sample test message.

--- a/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/body.html
+++ b/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/body.html
@@ -1,0 +1,20 @@
+template body.html
+
+{% for image_source in channel.tracker_image_sources %}
+    <img src="{{ image_source }}" alt="" role="presentation" aria-hidden="true" />
+{% endfor %}
+
+{% if channel.action_links %}
+<tr>
+    <!-- Actions -->
+    <td style="padding-bottom: 20px;">
+        {% for href, title in channel.action_links %}
+            <p>
+                <a href="{{ href }}" style="color: #960909">
+                    <font color="#960909"><b>{{ title }}</b></font>
+                </a>
+            </p>
+        {% endfor %}
+    </td>
+</tr>
+{% endif %}

--- a/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/body.txt
+++ b/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/body.txt
@@ -1,0 +1,1 @@
+template body.txt

--- a/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/from_name.txt
+++ b/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/from_name.txt
@@ -1,0 +1,1 @@
+template from_name.txt

--- a/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/head.html
+++ b/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/head.html
@@ -1,0 +1,1 @@
+template head.html

--- a/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/subject.txt
+++ b/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/subject.txt
@@ -1,0 +1,1 @@
+template subject.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,59 +6,59 @@
 #
 argparse==1.4.0           # via caniusepython3, stevedore
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
-attrs==17.2.0
-backports.functools-lru-cache==1.4  # via caniusepython3
-caniusepython3==5.0.0
-certifi==2017.7.27.1      # via requests
+attrs==17.4.0
+backports.functools-lru-cache==1.5  # via caniusepython3
+caniusepython3==6.0.0
+certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
-diff-cover==0.9.12
-distlib==0.2.5            # via caniusepython3
-django==1.11.5            # via edx-i18n-tools
-edx-i18n-tools==0.4.2
-edx-lint==0.5.4
+diff-cover==1.0.2
+distlib==0.2.7            # via caniusepython3
+django==1.11.12
+edx-i18n-tools==0.4.4
+edx-lint==0.5.5
 first==2.0.1              # via pip-tools
 futures==3.1.1            # via caniusepython3
 idna==2.6                 # via requests
 inflect==0.2.5            # via jinja2-pluralize
-isort==4.2.15
+isort==4.3.4
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.9.6             # via diff-cover, jinja2-pluralize
+jinja2==2.10              # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
-packaging==16.8           # via caniusepython3
-path.py==10.4             # via edx-i18n-tools
-pbr==3.1.1                # via stevedore
-pip-tools==1.9.0
-pkginfo==1.4.1            # via twine
-pluggy==0.5.2             # via tox
-polib==1.0.8              # via edx-i18n-tools
-py==1.4.34                # via tox
-pycodestyle==2.3.1
-pydocstyle==2.0.0
+packaging==17.1           # via caniusepython3
+path.py==11.0.1           # via edx-i18n-tools
+pbr==4.0.2                # via stevedore
+pip-tools==2.0.1
+pkginfo==1.4.2            # via twine
+pluggy==0.6.0             # via tox
+polib==1.1.0              # via edx-i18n-tools
+py==1.5.3                 # via tox
+pycodestyle==2.4.0
+pydocstyle==2.1.1
 pygments==2.2.0           # via diff-cover
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.2.0          # via packaging
-python-dateutil==2.6.1
-pytz==2017.2              # via django
+python-dateutil==2.7.2
+pytz==2018.4              # via django
 pyyaml==3.12              # via edx-i18n-tools
 requests-toolbelt==0.8.0  # via twine
 requests==2.18.4          # via caniusepython3, requests-toolbelt, sailthru-client, twine
 sailthru-client==2.2.3
-simplejson==3.11.1        # via sailthru-client
-six==1.11.0               # via astroid, diff-cover, edx-i18n-tools, edx-lint, packaging, pip-tools, pydocstyle, pylint, python-dateutil, stevedore
+simplejson==3.13.2        # via sailthru-client
+six==1.11.0               # via astroid, diff-cover, edx-i18n-tools, edx-lint, packaging, pip-tools, pydocstyle, pylint, python-dateutil, stevedore, tox
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.10.0
 tox-battery==0.2
-tox==2.8.2
-tqdm==4.17.1              # via twine
-twine==1.9.1
+tox==3.0.0
+tqdm==4.23.0              # via twine
+twine==1.11.0
 urllib3==1.22             # via requests
-virtualenv==15.1.0        # via tox
-wheel==0.30.0
+virtualenv==15.2.0        # via tox
+wheel==0.31.0
 wrapt==1.10.11            # via astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,32 +6,38 @@
 #
 alabaster==0.7.10         # via sphinx
 argparse==1.4.0           # via stevedore
-attrs==17.2.0
-babel==2.5.1              # via sphinx
-bleach==2.0.0             # via readme-renderer
-certifi==2017.7.27.1      # via requests
+attrs==17.4.0
+babel==2.5.3              # via sphinx
+bleach==2.1.3             # via readme-renderer
+certifi==2018.4.16        # via requests
+cffi==1.11.5              # via cmarkgfm
 chardet==3.0.4            # via doc8, requests
-django==1.11.5
+cmarkgfm==0.4.0           # via readme-renderer
+django==2.0.4
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.2.0
-html5lib==0.999999999     # via bleach
+edx-sphinx-theme==1.3.0
+future==0.16.0            # via readme-renderer
+html5lib==1.0.1           # via bleach
 idna==2.6                 # via requests
-imagesize==0.7.1          # via sphinx
-jinja2==2.9.6             # via sphinx
+imagesize==1.0.0          # via sphinx
+jinja2==2.10              # via sphinx
 markupsafe==1.0           # via jinja2
-pbr==3.1.1                # via stevedore
+packaging==17.1           # via sphinx
+pbr==4.0.2                # via stevedore
+pycparser==2.18           # via cffi
 pygments==2.2.0           # via readme-renderer, sphinx
-python-dateutil==2.6.1
-pytz==2017.2              # via babel, django
-readme-renderer==17.2
+pyparsing==2.2.0          # via packaging
+python-dateutil==2.7.2
+pytz==2018.4              # via babel, django
+readme-renderer==20.0
 requests==2.18.4          # via sailthru-client, sphinx
-restructuredtext-lint==1.1.1  # via doc8
+restructuredtext-lint==1.1.3  # via doc8
 sailthru-client==2.2.3
-simplejson==3.11.1        # via sailthru-client
-six==1.11.0               # via bleach, doc8, edx-sphinx-theme, html5lib, python-dateutil, readme-renderer, sphinx, stevedore
+simplejson==3.13.2        # via sailthru-client
+six==1.11.0               # via bleach, doc8, edx-sphinx-theme, html5lib, packaging, python-dateutil, readme-renderer, sphinx, stevedore
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.6.4             # via edx-sphinx-theme
+sphinx==1.7.2
 sphinxcontrib-websupport==1.0.1  # via sphinx
 stevedore==1.10.0
 urllib3==1.22             # via requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,22 +6,22 @@
 #
 argparse==1.4.0           # via caniusepython3
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
-backports.functools-lru-cache==1.4  # via caniusepython3
-caniusepython3==5.0.0
-certifi==2017.7.27.1      # via requests
+backports.functools-lru-cache==1.5  # via caniusepython3
+caniusepython3==6.0.0
+certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint
-distlib==0.2.5            # via caniusepython3
-edx-lint==0.5.4
+distlib==0.2.7            # via caniusepython3
+edx-lint==0.5.5
 futures==3.1.1            # via caniusepython3
 idna==2.6                 # via requests
-isort==4.2.15
+isort==4.3.4
 lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via pylint
-packaging==16.8           # via caniusepython3
-pycodestyle==2.3.1
-pydocstyle==2.0.0
+packaging==17.1           # via caniusepython3
+pycodestyle==2.4.0
+pydocstyle==2.1.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,30 +5,32 @@
 #    pip-compile --output-file requirements/test.txt requirements/base.in requirements/test.in
 #
 argparse==1.4.0           # via stevedore
-attrs==17.2.0
-certifi==2017.7.27.1      # via requests
+attrs==17.4.0
+certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
-coverage==4.4.1           # via hypothesis, pytest-cov
-ddt==1.1.1
+coverage==4.5.1           # via hypothesis, pytest-cov
+ddt==1.1.2
 hypothesis-pytest==0.19.0
-hypothesis[pytz]==3.30.3
+hypothesis[pytz]==3.56.0
 idna==2.6                 # via requests
 mock==2.0.0
-pbr==3.1.1                # via mock, stevedore
+more-itertools==4.1.0     # via pytest
+pbr==4.0.2                # via mock, stevedore
+pluggy==0.6.0             # via pytest
 pudb==2017.1.4
-py==1.4.34                # via pytest, pytest-catchlog
+py==1.5.3                 # via pytest, pytest-catchlog
 pygments==2.2.0           # via pudb
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest-randomly==1.2.1
-pytest==3.2.2             # via hypothesis-pytest, pytest-catchlog, pytest-cov, pytest-django, pytest-randomly
-python-dateutil==2.6.1
-pytz==2017.2              # via django, hypothesis
+pytest-django==3.2.1
+pytest-randomly==1.2.3
+pytest==3.5.0             # via hypothesis-pytest, pytest-catchlog, pytest-cov, pytest-django, pytest-randomly
+python-dateutil==2.7.2
+pytz==2018.4              # via django, hypothesis
 requests==2.18.4          # via sailthru-client
 sailthru-client==2.2.3
-simplejson==3.11.1        # via sailthru-client
-six==1.11.0               # via mock, python-dateutil, stevedore
+simplejson==3.13.2        # via sailthru-client
+six==1.11.0               # via mock, more-itertools, pytest, python-dateutil, stevedore
 stevedore==1.10.0
 urllib3==1.22             # via requests
-urwid==1.3.1              # via pudb
+urwid==2.0.1              # via pudb

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,15 +4,16 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
-certifi==2017.7.27.1      # via requests
+certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.9
-coverage==4.4.1           # via codecov
+codecov==2.0.15
+coverage==4.5.1           # via codecov
 idna==2.6                 # via requests
-pluggy==0.5.2             # via tox
-py==1.4.34                # via tox
+pluggy==0.6.0             # via tox
+py==1.5.3                 # via tox
 requests==2.18.4          # via codecov
+six==1.11.0               # via tox
 tox-battery==0.2
-tox==2.8.2
+tox==3.0.0
 urllib3==1.22             # via requests
-virtualenv==15.1.0        # via tox
+virtualenv==15.2.0        # via tox

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         'openedx.ace.channel': [
             'sailthru_email = edx_ace.channel.sailthru:SailthruEmailChannel',
             'file_email = edx_ace.channel.file:FileEmailChannel',
+            'django_email = edx_ace.channel.django_email:DjangoEmailChannel',
         ]
     }
 )

--- a/test_settings.py
+++ b/test_settings.py
@@ -43,3 +43,24 @@ ROOT_URLCONF = 'edx_ace.urls'
 SECRET_KEY = 'insecure-secret-key'
 
 ACE_ENABLED_POLICIES = []
+ACE_CHANNEL_DEFAULT_EMAIL = 'sailthru_email'
+ACE_CHANNEL_TRANSACTIONAL_EMAIL = 'file_email'
+
+ACE_ENABLED_CHANNELS = [
+    'sailthru_email',
+    'file_email',
+]
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            root('edx_ace', 'tests', 'test_templates'),
+        ],
+    },
+]
+
+ACE_CHANNEL_SAILTHRU_DEBUG = True
+ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME = 'Automated Communication Engine Email'
+ACE_CHANNEL_SAILTHRU_API_KEY = None
+ACE_CHANNEL_SAILTHRU_API_SECRET = None


### PR DESCRIPTION
**Description:** This PR adds `send_mail()` function from Django to ACE as an alternative to Sailthru. This is a follow up to my email PR (https://github.com/edx/edx-platform/pull/16545).

**Merge deadline:** I have no deadline, but https://github.com/edx/edx-platform/pull/16545 has been going on for a while, so I'd really appreciate it to speed this up.

**Installation instructions:** Please do `pip install -e .` to have the new entry points installed.
instructions.

**Testing instructions:**
Not sure how to test this standalone, but generally to send a message the following needs to be configured:

```python
ACE_CHANNEL_DEFAULT_EMAIL=u'file_email',
ACE_CHANNEL_TRANSACTIONAL_EMAIL=u'django_email',
ACE_ENABLED_CHANNELS=[u'django_email', u'file_email'],
```

**Reviewers:**
- [x] @mulby 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [ ] ~~Changelog record added~~
     * Too much missing changelogs to trackback. Out of the scope of this PR.
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
 - [x] I'm not totally happy with `ACE_CHANNEL_DJANGO_FROM_ADDRESS_GETTER`, but it works OK for now. If you have any suggestions please let me know!
   * Replaced with `message.options['from_email']`
 - [x] Is `django_email` the correct name? 
   * Looks like it.