### PR TITLE
support transactional email

### DIFF
--- a/edx_ace/ace.py
+++ b/edx_ace/ace.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, division, print_function
 import six
 
 from edx_ace import delivery, policy, presentation
+from edx_ace.channel import get_channel_for_channel_type
 from edx_ace.errors import ChannelError
 
 
@@ -47,9 +48,10 @@ def send(msg):
 
     channels_for_message = policy.channels_for(msg)
     for channel_type in channels_for_message:
+        channel = get_channel_for_channel_type(channel_type, msg)
         try:
-            rendered_message = presentation.render(channel_type, msg)
-            delivery.deliver(channel_type, rendered_message, msg)
+            rendered_message = presentation.render(channel, msg)
+            delivery.deliver(channel, rendered_message, msg)
         except ChannelError as error:
             msg.report(
                 u'{channel_type}_error'.format(channel_type=channel_type),

--- a/edx_ace/channel/file.py
+++ b/edx_ace/channel/file.py
@@ -58,7 +58,7 @@ class FileEmailChannel(Channel):
     By default it writes the output file to /edx/src/ace_output.html and overwrites any existing file at that location.
     In the edX devstack, this folder is shared between the host and the containers so you can easily open the file using
     a browser on the host. You can override this output file location by passing in a ``output_file_path`` key in the
-    message context. That path specifies where in the container filesystem the file should be written.
+    message options. That path specifies where in the container filesystem the file should be written.
 
     Both streams of output are UTF-8 encoded.
     """
@@ -77,7 +77,7 @@ class FileEmailChannel(Channel):
         template_vars[u'email_address'] = message.recipient.email_address
 
         rendered_template = TEMPLATE.format(**template_vars)
-        output_file_path = message.context.get(PATH_OVERRIDE_KEY, DEFAULT_OUTPUT_FILE_PATH_TPL.format(
+        output_file_path = message.options.get(PATH_OVERRIDE_KEY, DEFAULT_OUTPUT_FILE_PATH_TPL.format(
             recipient=message.recipient,
             date=datetime.now()
         ))

--- a/edx_ace/channel/sailthru.py
+++ b/edx_ace/channel/sailthru.py
@@ -10,6 +10,7 @@ import random
 import textwrap
 from datetime import datetime, timedelta
 from enum import Enum
+from gettext import gettext as _
 
 import attr
 import six
@@ -148,6 +149,13 @@ class SailthruEmailChannel(Channel):
             hasattr(settings, required_setting)
             for required_setting in required_settings
         )
+
+    @property
+    def action_links(self):
+        return [
+            ('{view_url}', _('View on Web')),
+            ('{optout_confirm_url}', _('Unsubscribe from this list')),
+        ]
 
     def __init__(self):
         if not self.enabled():

--- a/edx_ace/delivery.py
+++ b/edx_ace/delivery.py
@@ -10,12 +10,9 @@ import datetime
 import logging
 import time
 
-import six
-
 from django.conf import settings
 
-from edx_ace.channel import channels
-from edx_ace.errors import RecoverableChannelDeliveryError, UnsupportedChannelError
+from edx_ace.errors import RecoverableChannelDeliveryError
 from edx_ace.utils.date import get_current_time
 
 LOG = logging.getLogger(__name__)
@@ -29,12 +26,12 @@ LOG = logging.getLogger(__name__)
 MAX_EXPIRATION_DELAY = 5 * 60
 
 
-def deliver(channel_type, rendered_message, message):
+def deliver(channel, rendered_message, message):
     u"""
     Deliver a message via a particular channel.
 
     Args:
-        channel_type (ChannelType): The channel type to deliver the channel over.
+        channel (Channel): The channel to deliver the message over.
         rendered_message (object): Each attribute of this object contains rendered content.
         message (Message): The message that is being sent.
 
@@ -42,15 +39,8 @@ def deliver(channel_type, rendered_message, message):
         :class:`.UnsupportedChannelError`: If no channel of the requested channel type is available.
 
     """
-    channel = channels().get(channel_type)
-    if not channel:
-        raise UnsupportedChannelError(
-            u'No implementation for channel {channel_type} registered. Available channels are: {channels}'.format(
-                channel_type=channel_type,
-                channels=u', '.join(six.text_type(registered_channel_type) for registered_channel_type in channels())
-            )
-        )
     logger = message.get_message_specific_logger(LOG)
+    channel_type = channel.channel_type
 
     timeout_seconds = getattr(settings, u'ACE_DEFAULT_EXPIRATION_DELAY', 120)
     start_time = get_current_time()

--- a/edx_ace/message.py
+++ b/edx_ace/message.py
@@ -77,11 +77,16 @@ class Message(MessageAttributeSerializationMixin):
         validator=attr.validators.optional(attr.validators.instance_of(UUID)),
         default=None
     )
+    options = attr.ib()
     language = attr.ib(default=None)
     log_level = attr.ib(default=None)
 
     @context.default
     def default_context_value(self):
+        return {}
+
+    @options.default
+    def default_options_value(self):
         return {}
 
     @uuid.default
@@ -176,10 +181,15 @@ class MessageType(MessageAttributeSerializationMixin):
     )
     app_label = attr.ib()
     name = attr.ib()
+    options = attr.ib()
     log_level = attr.ib(default=None)
 
     @context.default
     def default_context_value(self):
+        return {}
+
+    @options.default
+    def default_options_value(self):
         return {}
 
     @uuid.default
@@ -227,6 +237,7 @@ class MessageType(MessageAttributeSerializationMixin):
             recipient=recipient,
             language=language,
             log_level=self.log_level,
+            options=self.options,
         )
 
     # We override these so that a subtype of MessageType can compare equal

--- a/edx_ace/presentation.py
+++ b/edx_ace/presentation.py
@@ -10,6 +10,7 @@ from django.utils import translation
 from edx_ace import errors, renderers
 from edx_ace.channel import ChannelType
 
+
 RENDERERS = {
     ChannelType.EMAIL: renderers.EmailRenderer(),
 }
@@ -17,12 +18,12 @@ RENDERERS = {
 
 def render(channel, message):
     u""" Returns the rendered content for the given channel and message. """
-    renderer = RENDERERS.get(channel)
+    renderer = RENDERERS.get(channel.channel_type)
 
     if not renderer:
-        error_msg = u'No renderer is registered for the channel [{}].'.format(channel)
+        error_msg = u'No renderer is registered for the channel type [{}].'.format(channel.channel_type)
         raise errors.UnsupportedChannelError(error_msg)
 
     message_language = message.language or translation.get_language()
     with translation.override(message_language):
-        return renderer.render(message)
+        return renderer.render(channel, message)

--- a/edx_ace/renderers.py
+++ b/edx_ace/renderers.py
@@ -22,14 +22,14 @@ class AbstractRenderer(object):
     and context, and outputting a rendered message for a specific message
     channel (e.g. email, SMS, push notification).
     """
-    channel = None
     rendered_message_cls = None
 
-    def render(self, message):
+    def render(self, channel, message):
         u"""
         Renders the given message.
 
         Args:
+             channel (Channel)
              message (Message)
 
          Returns:
@@ -44,16 +44,17 @@ class AbstractRenderer(object):
                 filename = field.replace(u'_html', u'.html')
             else:
                 filename = field + u'.txt'
-            template = self.get_template_for_message(message, filename)
+            template = self.get_template_for_message(channel, message, filename)
             render_context = {
                 u'message': message,
+                u'channel': channel,
             }
             render_context.update(message.context)
             rendered[field] = template.render(render_context)
 
         return self.rendered_message_cls(**rendered)  # pylint: disable=not-callable
 
-    def get_template_for_message(self, message, filename):
+    def get_template_for_message(self, channel, message, filename):
         u"""
         Arguments:
             message (:class:`Message`): The message being rendered.
@@ -62,10 +63,10 @@ class AbstractRenderer(object):
         Returns:
             The full template path to the template to render.
         """
-        template_path = u'{app_label}/edx_ace/{name}/{channel}/{filename}'.format(
+        template_path = u'{app_label}/edx_ace/{name}/{channel_type}/{filename}'.format(
             app_label=message.app_label,
             name=message.name,
-            channel=self.channel.value,
+            channel_type=channel.channel_type.value,
             filename=filename,
         )
         return loader.get_template(template_path)
@@ -88,5 +89,4 @@ class EmailRenderer(AbstractRenderer):
     u"""
     A renderer for :attr:`.ChannelType.EMAIL` channels.
     """
-    channel = ChannelType.EMAIL
     rendered_message_cls = RenderedEmail

--- a/edx_ace/tests/test_message.py
+++ b/edx_ace/tests/test_message.py
@@ -54,6 +54,9 @@ class TestMessage(TestCase):
                 u'key1': u'value1',
                 u'key2': u'value2',
             },
+            u'options': {
+                u'transactional': True,
+            },
             u'recipient': Recipient(
                 username=u'me',
             )


### PR DESCRIPTION
@OmarIthawi here's a sketch of the changes I was envisioning for ACE.

Major changes:
* Pass around concrete channel objects instead of channel types
* Pass the channel object into the template at render time
* Allow options to be passed into ACE on messages
* Support multiple implementations for channel types (e.g. multiple email channels registered to the email channel type)
* Support routing of transactional email to a different channel type

This is intended to be paired with https://github.com/edx/edx-platform/pull/17504

TODO:
- [ ] tests
- [ ] quality
- [ ] handle the case when the new settings aren't defined
- [ ] update doc strings