### PR TITLE
WL-1388: added ability to set from_email address in ace messages

### DIFF
--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -15,7 +15,7 @@ from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 from .channel import ChannelType, Channel
 
-__version__ = u'0.1.7'
+__version__ = u'0.1.8'
 
 default_app_config = u'edx_ace.apps.EdxAceConfig'
 

--- a/edx_ace/channel/sailthru.py
+++ b/edx_ace/channel/sailthru.py
@@ -183,12 +183,15 @@ class SailthruEmailChannel(Channel):
                 message.log_id
             )
 
-        template_vars = {}
+        template_vars, options = {}, {}
         for key, value in six.iteritems(attr.asdict(rendered_message)):
             if value is not None:
                 # Sailthru will silently fail to send the email if the from name or subject line contain new line
                 # characters at the beginning or end of the string
                 template_vars[u'ace_template_' + key] = value.strip()
+
+        if u'from_address' in message.options:
+            options[u'behalf_email'] = message.options.get(u'from_address')
 
         logger = message.get_message_specific_logger(LOG)
 
@@ -200,10 +203,12 @@ class SailthruEmailChannel(Channel):
                         template: %s
                         recipient: %s
                         variables: %s
+                        options: %s
                 """),
                 self.template_name,
                 message.recipient.email_address,
                 six.text_type(template_vars),
+                six.text_type(options),
             )
             return
 
@@ -214,10 +219,12 @@ class SailthruEmailChannel(Channel):
                         template: %s
                         recipient: %s
                         variables: %s
+                        options: %s
                 """),
                 self.template_name,
                 message.recipient.email_address,
                 six.text_type(template_vars),
+                six.text_type(options),
             )
 
         try:
@@ -227,6 +234,7 @@ class SailthruEmailChannel(Channel):
                 self.template_name,
                 message.recipient.email_address,
                 _vars=template_vars,
+                options=options,
             )
 
             if response.is_ok():

--- a/edx_ace/tests/channel/test_sailthru.py
+++ b/edx_ace/tests/channel/test_sailthru.py
@@ -1,17 +1,25 @@
 # pylint: disable=missing-docstring
 from __future__ import absolute_import
 
-from django.test import TestCase
+import ddt
+from mock import patch
+
+from django.test import TestCase, override_settings
 
 from edx_ace.channel.sailthru import SailthruEmailChannel
+from edx_ace.delivery import deliver
 from edx_ace.message import Message
 from edx_ace.presentation import render
 from edx_ace.recipient import Recipient
 
 
+@ddt.ddt
 class TestSailthruChannel(TestCase):
+
+    def setUp(self):
+        self.channel = SailthruEmailChannel()
+
     def test_render_email_with_sailthru(self):
-        channel = SailthruEmailChannel()
         message = Message(
             app_label=u'testapp',
             name=u'testmessage',
@@ -19,8 +27,34 @@ class TestSailthruChannel(TestCase):
             recipient=Recipient(username=u'Robot', email_address=u'mr@robot.io'),
         )
 
-        rendered_email = render(channel, message)
+        rendered_email = render(self.channel, message)
 
         assert u'{beacon_src}' in rendered_email.body_html
         assert u'{view_url}' in rendered_email.body_html
         assert u'{optout_confirm_url}' in rendered_email.body_html
+
+    @override_settings(
+        ACE_CHANNEL_SAILTHRU_DEBUG=False,
+    )
+    @ddt.data(
+        ({u'from_address': 'custom@example.com'}, {u'behalf_email': 'custom@example.com'}),
+        ({u'irrelevant': 'test'}, {}),
+        ({}, {}),
+    )
+    @ddt.unpack
+    def test_on_behalf_option_with_sailthru(self, message_options, expected_options):
+        """
+        Tests sailthru send API is called with on_behalf option
+        """
+        from_address = 'custom@example.com'
+        message = Message(
+            app_label=u'testapp',
+            name=u'testmessage',
+            options=message_options,
+            recipient=Recipient(username=u'Robot', email_address=u'mr@robot.io'),
+        )
+        rendered_email = render(self.channel, message)
+
+        with patch('edx_ace.channel.sailthru.SailthruClient.send') as mock_send:
+            deliver(self.channel, rendered_email, message)
+            self.assertEqual(mock_send.call_args_list[0][1]['options'], expected_options)


### PR DESCRIPTION
**Description:** This PR has changes to set from email address of email messages sent via sailthru email channel. It uses `behalf_email` option of sailthru send API to achieve that.

**JIRA:** https://openedx.atlassian.net/browse/WL-1388

**Reviewers:**
- [x] tag reviwer 
- [ ] tag reviewer 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
