### PR TITLE
added reply_to functionality in django email and sailthru 

### DIFF
--- a/edx_ace/channel/sailthru.py
+++ b/edx_ace/channel/sailthru.py
@@ -190,7 +190,9 @@ class SailthruEmailChannel(Channel):
                 # characters at the beginning or end of the string
                 template_vars[u'ace_template_' + key] = value.strip()
 
-        if u'from_address' in message.options:
+        if u'reply_to' in message.options and message.options.get(u'reply_to'):
+            options[u'behalf_email'] = message.options.get(u'reply_to')
+        elif u'from_address' in message.options:
             options[u'behalf_email'] = message.options.get(u'from_address')
 
         logger = message.get_message_specific_logger(LOG)

--- a/edx_ace/tests/channel/test_sailthru.py
+++ b/edx_ace/tests/channel/test_sailthru.py
@@ -38,6 +38,7 @@ class TestSailthruChannel(TestCase):
     )
     @ddt.data(
         ({u'from_address': 'custom@example.com'}, {u'behalf_email': 'custom@example.com'}),
+        ({u'reply_to': 'student@example.com'}, {u'behalf_email': 'student@example.com'}),
         ({u'irrelevant': 'test'}, {}),
         ({}, {}),
     )
@@ -46,7 +47,6 @@ class TestSailthruChannel(TestCase):
         """
         Tests sailthru send API is called with on_behalf option
         """
-        from_address = 'custom@example.com'
         message = Message(
             app_label=u'testapp',
             name=u'testmessage',


### PR DESCRIPTION
For django email replaced send_email with EmailMultiAlternatives. Both are wrapper of EmailMessage but send_email has limited options e.g it does't have reply_to, CC, BCC options.
BTW below the surface send_email is using EmailMultiAlternatives that's using it directly because it would give extra options.
EmailMultiAlternatives is version of EmailMessage that makes it easy to send multipart/alternative messages. For example, including text and HTML versions of the text is made easier.

For sailthru we already using behalf_option. Assigned it reply_to value.
