### PR TITLE
Fix warning from use of deprecated kwarg to @attr.s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 *
 
+[0.1.14] - 2020-03-11
+~~~~~~~~~~~~~~~~~~~~~
+
+* Fix trivial warning from deprecated use of attr library.
+
 [0.1.13] - 2019-12-06
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -15,7 +15,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = u'0.1.13'
+__version__ = u'0.1.14'
 
 default_app_config = u'edx_ace.apps.EdxAceConfig'
 

--- a/edx_ace/message.py
+++ b/edx_ace/message.py
@@ -149,7 +149,7 @@ class MessageLoggingAdapter(logging.LoggerAdapter):
             super(MessageLoggingAdapter, self).debug(msg, *args, **kwargs)
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False, order=False)
 class MessageType(MessageAttributeSerializationMixin):
     u"""
     A class representing a type of :class:`Message`. An instance of


### PR DESCRIPTION
The `cmp` kwarg is deprecated in calls to `@attr.s`, and should be replaced with `eq` and `order`.

This will fix a warning in edx-platform and any other repo that uses this package.

See http://www.attrs.org/en/stable/changelog.html#id3 for details.