### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 *
 
+[0.1.18] - 2020-11-19
+~~~~~~~~~~~~~~~~~~~~~
+
+* Updated he travis-badge in README.rst to point to travis-ci.com
+
 [0.1.17] - 2020-10-19
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,8 @@ refer to this `list of resources <https://open.edx.org/getting-help>`_ if you ne
     :target: https://pypi.python.org/pypi/edx-ace/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.org/edx/edx-ace.svg?branch=master
-    :target: https://travis-ci.org/edx/edx-ace
+.. |travis-badge| image:: https://travis-ci.com/edx/edx-ace.svg?branch=master
+    :target: https://travis-ci.com/edx/edx-ace
     :alt: Travis
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/edx-ace/coverage.svg?branch=master

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '0.1.17'
+__version__ = '0.1.18'
 
 default_app_config = 'edx_ace.apps.EdxAceConfig'
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089