### PR TITLE
feat!: add new braze_email backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Change Log
    in this file.  It adheres to the structure of http://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (http://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
@@ -15,6 +15,17 @@ Unreleased
 ~~~~~~~~~~
 
 *
+
+[1.0.0] - 2021-03-11
+~~~~~~~~~~~~~~~~~~~~
+
+* BREAKING: Recipient objects now take `lms_user_id` instead of `username`
+* New `braze_email` backend, needing the following new configuration:
+
+  * ACE_CHANNEL_BRAZE_API_KEY
+  * ACE_CHANNEL_BRAZE_APP_ID
+  * ACE_CHANNEL_BRAZE_REST_ENDPOINT (like `rest.iad-01.braze.com`)
+  * ACE_CHANNEL_BRAZE_CAMPAIGNS (an optional dictionary of ACE message names to Braze campaign identifiers)
 
 [0.1.18] - 2020-11-19
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -107,7 +107,7 @@ The simplest way to send a message using ACE is to just create it, and call :py:
     msg = Message(
         name="test_message",
         app_label="my_app",
-        recipient=Recipient(username='a_user', email='a_user@example.com'),
+        recipient=Recipient(lms_user_id='123456', email='a_user@example.com'),
         language='en',
         context={
             'stuff': 'to personalize the message',

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '0.1.18'
+__version__ = '1.0.0'
 
 default_app_config = 'edx_ace.apps.EdxAceConfig'
 

--- a/edx_ace/ace.py
+++ b/edx_ace/ace.py
@@ -11,7 +11,7 @@ Usage:
     msg = Message(
         name="test_message",
         app_label="my_app",
-        recipient=Recipient(username='a_user', email='a_user@example.com'),
+        recipient=Recipient(lms_user_id='123456', email='a_user@example.com'),
         language='en',
         context={
             'stuff': 'to personalize the message',

--- a/edx_ace/channel/braze.py
+++ b/edx_ace/channel/braze.py
@@ -1,0 +1,188 @@
+"""
+:mod:`edx_ace.channel.braze` implements a Braze-based email delivery channel for ACE.
+"""
+import logging
+import random
+from datetime import timedelta
+
+import requests
+
+from django.conf import settings
+
+from edx_ace.channel import Channel
+from edx_ace.channel.django_email import DjangoEmailChannel
+from edx_ace.channel.mixins import EmailChannelMixin
+from edx_ace.errors import FatalChannelDeliveryError, RecoverableChannelDeliveryError
+from edx_ace.utils.date import get_current_time
+
+LOG = logging.getLogger(__name__)
+
+NEXT_ATTEMPT_DELAY_SECONDS = 30
+
+
+class BrazeEmailChannel(EmailChannelMixin, Channel):
+    """
+    An email channel for delivering messages to users using Braze.
+
+    This channel makes use of the Braze REST API to send messages. It is designed for "at most once" delivery of
+    messages. It will make a reasonable attempt to deliver the message and give up if it can't. It also only confirms
+    that Braze has received the request to send the email, it doesn't actually confirm that it made it to the
+    recipient.
+
+    See the Braze documentation for message sending, for more information:
+    https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_messages/
+
+    The recipient email address is ignored, instead Braze uses its stored email address for the recipient. Although,
+    if the lms_user_id is not valid, this channel falls back to the Django email channel and then the address will
+    be used.
+
+    The integration with Braze requires several Django settings to be defined.
+
+    The ACE_CHANNEL_BRAZE_CAMPAIGNS setting is optional, but if it is defined, it should be a mapping of ACE message
+    names to campaign ids. And optionally a message variation id, separated by a colon. See the example below.
+
+    Example:
+
+        Sample settings::
+
+            .. settings_start
+            ACE_CHANNEL_BRAZE_API_KEY = "1c304d0d-c800-4da3-bfaa-41b1189b34cb"
+            ACE_CHANNEL_BRAZE_APP_ID = "f6232495-6ad6-4310-bab5-5673768856aa"
+            ACE_CHANNEL_BRAZE_REST_ENDPOINT = "rest.iad-01.braze.com"
+            ACE_CHANNEL_BRAZE_CAMPAIGNS = {
+                "deletionnotificationmessage": "campaign_id:variation_id"
+            }
+            .. settings_end
+    """
+
+    _API_KEY_SETTING = 'ACE_CHANNEL_BRAZE_API_KEY'
+    _APP_ID_SETTING = 'ACE_CHANNEL_BRAZE_APP_ID'
+    _CAMPAIGNS_SETTING = 'ACE_CHANNEL_BRAZE_CAMPAIGNS'  # optional
+    _ENDPOINT_SETTING = 'ACE_CHANNEL_BRAZE_REST_ENDPOINT'
+
+    @classmethod
+    def enabled(cls):
+        """
+        Returns: True iff all required settings are not empty and the Braze client library is installed.
+        """
+        ok = True
+
+        for setting in (
+            cls._API_KEY_SETTING,
+            cls._APP_ID_SETTING,
+            cls._ENDPOINT_SETTING,
+        ):
+            if not getattr(settings, setting, None):
+                ok = False
+                LOG.warning('%s is not set, Braze email channel is disabled.', setting)
+
+        return ok
+
+    def deliver(self, message, rendered_message):
+        if not self.enabled():
+            raise FatalChannelDeliveryError('Braze channel is disabled, unable to send')
+
+        if not message.recipient.lms_user_id:
+            # This channel assumes that you have Braze configured with LMS user_ids as your external_user_id in Braze.
+            # Unfortunately, that means that we can't send emails to users that aren't registered with the LMS,
+            # which some callers of ACE may attempt to do (despite the lms_user_id being a required Recipient field).
+            # In these cases, we fall back to a simple Django smtp email.
+            DjangoEmailChannel().deliver(message, rendered_message)
+            return
+
+        transactional = message.options.get('transactional', False)
+        body_html = self.make_simple_html_template(rendered_message.head_html, rendered_message.body_html)
+
+        logger = message.get_message_specific_logger(LOG)
+        logger.debug('Sending to Braze')
+
+        # https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_messages/
+        response = requests.post(
+            self._send_url(),
+            headers=self._auth_headers(),
+            json={
+                'external_user_ids': [str(message.recipient.lms_user_id)],
+                'recipient_subscription_state': 'all' if transactional else 'subscribed',
+                'campaign_id': self._campaign_id(message.name),
+                'messages': {
+                    'email': {
+                        'app_id': getattr(settings, self._APP_ID_SETTING),
+                        'subject': self.get_subject(rendered_message),
+                        'from': self.get_from_address(message),
+                        'reply_to': message.options.get('reply_to'),
+                        'body': body_html,
+                        'plaintext_body': rendered_message.body,
+                        'message_variation_id': self._variation_id(message.name),
+                    },
+                },
+            },
+        )
+
+        try:
+            response.raise_for_status()
+            logger.debug('Successfully sent to Braze (dispatch ID %s)', response.json()['dispatch_id'])
+
+        except requests.exceptions.HTTPError as exc:
+            # https://www.braze.com/docs/api/errors/
+            message = response.json().get('message', 'Unknown error')
+            logger.debug('Failed to send to Braze: %s', message)
+            self._handle_error_response(response, message, exc)
+
+    def _handle_error_response(self, response, message, exception):
+        """
+        Handle an error response from Braze, either by retrying or failing
+        with an appropriate exception.
+
+        Arguments:
+            response: The HTTP response received from Braze.
+            message: An error message from Braze.
+            exception: The exception that triggered this error.
+        """
+        if response.status_code == 429 or 500 <= response.status_code < 600:
+            next_attempt_time = get_current_time() + timedelta(
+                seconds=NEXT_ATTEMPT_DELAY_SECONDS + random.uniform(-2, 2)
+            )
+            raise RecoverableChannelDeliveryError(
+                'Recoverable Braze error (status_code={http_status_code}): {message}'.format(
+                    http_status_code=response.status_code,
+                    message=message
+                ),
+                next_attempt_time
+            ) from exception
+
+        raise FatalChannelDeliveryError(
+            'Fatal Braze error (status_code={http_status_code}): {message}'.format(
+                http_status_code=response.status_code,
+                message=message
+            )
+        ) from exception
+
+    @classmethod
+    def _auth_headers(cls):
+        """Returns authorization headers suitable for passing to the requests library"""
+        return {
+            'Authorization': 'Bearer ' + getattr(settings, cls._API_KEY_SETTING),
+        }
+
+    @classmethod
+    def _send_url(cls):
+        """Returns the send-message API URL"""
+        return 'https://{url}/messages/send'.format(url=getattr(settings, cls._ENDPOINT_SETTING))
+
+    @classmethod
+    def _campaign_id(cls, name):
+        """Returns the campaign ID for a given ACE message name or None if no match is found"""
+        campaign = getattr(settings, cls._CAMPAIGNS_SETTING, {}).get(name)
+        if campaign:
+            return campaign.split(':')[0]
+        return None
+
+    @classmethod
+    def _variation_id(cls, name):
+        """Returns the variation ID for a given ACE message name or None if no match is found"""
+        campaign = getattr(settings, cls._CAMPAIGNS_SETTING, {}).get(name)
+        if campaign:
+            campaign_parts = campaign.split(':')
+            if len(campaign_parts) > 1:
+                return campaign_parts[1]
+        return None

--- a/edx_ace/channel/file.py
+++ b/edx_ace/channel/file.py
@@ -13,7 +13,7 @@ from edx_ace.channel import Channel, ChannelType
 LOG = logging.getLogger(__name__)
 
 PATH_OVERRIDE_KEY = 'output_file_path'
-DEFAULT_OUTPUT_FILE_PATH_TPL = '/edx/src/ace_messages/{recipient.username}.{date:%Y%m%d-%H%M%S}.html'
+DEFAULT_OUTPUT_FILE_PATH_TPL = '/edx/src/ace_messages/{recipient.lms_user_id}.{date:%Y%m%d-%H%M%S}.html'
 TEMPLATE = """
 <!DOCTYPE html>
 <html>

--- a/edx_ace/channel/mixins.py
+++ b/edx_ace/channel/mixins.py
@@ -1,0 +1,44 @@
+"""
+:mod:`edx_ace.channel.mixins` implements some helper methods for channels
+"""
+import re
+
+from django.conf import settings
+
+from edx_ace.channel import ChannelType
+from edx_ace.errors import FatalChannelDeliveryError
+
+
+class EmailChannelMixin:
+    """
+    Adds some common email utility methods to email channels
+    """
+    channel_type = ChannelType.EMAIL
+
+    @staticmethod
+    def get_from_address(message):
+        """Grabs the from_address from the message with fallback and error handling"""
+        default_from_address = getattr(settings, 'DEFAULT_FROM_EMAIL', None)
+        from_address = message.options.get('from_address', default_from_address)
+        if not from_address:
+            raise FatalChannelDeliveryError(
+                'from_address must be included in message delivery options or as the DEFAULT_FROM_EMAIL settings'
+            )
+        return from_address
+
+    @staticmethod
+    def get_subject(rendered_message):
+        # Compress spaces and remove newlines to make it easier to author templates.
+        return re.sub('\\s+', ' ', rendered_message.subject, re.UNICODE).strip()
+
+    @staticmethod
+    def make_simple_html_template(head_html, body_html):
+        return """<!DOCTYPE html>
+<html>
+  <head>
+    {head_html}
+  </head>
+  <body>
+    {body_html}
+  </body>
+</html>""".format(head_html=head_html, body_html=body_html)

--- a/edx_ace/recipient.py
+++ b/edx_ace/recipient.py
@@ -13,8 +13,8 @@ class Recipient(MessageAttributeSerializationMixin):
     The target for a message.
 
     Arguments:
-        username (str): The username of the intended recipient.
+        lms_user_id (int): The LMS user ID of the intended recipient.
         email_address (str): The email address of the intended recipient. Optional.
     """
-    username = attr.ib()
+    lms_user_id = attr.ib()
     email_address = attr.ib(default=None)

--- a/edx_ace/tests/channel/test_braze.py
+++ b/edx_ace/tests/channel/test_braze.py
@@ -1,0 +1,139 @@
+"""Unit tests for braze.py"""
+from unittest.mock import Mock, patch
+
+import ddt
+import requests
+
+from django.test import TestCase, override_settings
+
+from edx_ace.channel.braze import BrazeEmailChannel
+from edx_ace.errors import FatalChannelDeliveryError, RecoverableChannelDeliveryError
+from edx_ace.message import Message
+from edx_ace.presentation import render
+from edx_ace.recipient import Recipient
+
+
+@ddt.ddt
+@override_settings(
+    ACE_CHANNEL_BRAZE_API_KEY='test-api-key',
+    ACE_CHANNEL_BRAZE_APP_ID='test-app-id',
+    ACE_CHANNEL_BRAZE_REST_ENDPOINT='rest.braze.com',
+    ACE_DEFAULT_EXPIRATION_DELAY=0,
+)
+class TestBrazeChannel(TestCase):
+    """Tests for the braze channel"""
+
+    def setUp(self):
+        self.channel = BrazeEmailChannel()
+
+    def deliver_email(self, lms_user_id=123, options=None, response_code=200, response_message='Success!'):
+        """Sets up all the mocks for a single email"""
+        message = Message(
+            app_label='testapp',
+            name='testmessage',
+            options=options or {},
+            recipient=Recipient(lms_user_id=lms_user_id, email_address='mr@robot.io'),
+        )
+        rendered_message = render(self.channel, message)
+
+        with patch('edx_ace.channel.braze.requests.post') as mock_post:
+            mock_response = Mock()
+            mock_response.status_code = response_code
+            mock_response.json.return_value = {'message': response_message, 'dispatch_id': 'test-dispatch-id'}
+            if response_code >= 400:
+                mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response)
+            mock_post.return_value = mock_response
+            self.channel.deliver(message, rendered_message)  # direct, so we can catch interesting exceptions ourselves
+
+        return mock_post
+
+    def test_happy_path(self):
+        """Basic email send, no special settings"""
+        mock_post = self.deliver_email()
+
+        assert mock_post.call_count == 1
+        assert mock_post.call_args[0] == ('https://rest.braze.com/messages/send',)
+        assert mock_post.call_args[1] == {
+            'headers': {'Authorization': 'Bearer test-api-key'},
+            'json': {
+                'external_user_ids': ['123'],
+                'recipient_subscription_state': 'subscribed',
+                'campaign_id': None,
+                'messages': {
+                    'email': {
+                        'app_id': 'test-app-id',
+                        'subject': 'template subject.txt',
+                        'from': 'webmaster@localhost',
+                        'reply_to': None,
+                        'body': """<!DOCTYPE html>
+<html>
+  <head>
+    template head.html\n
+  </head>
+  <body>
+    template body.html\n\n\n\n\n
+  </body>
+</html>""",
+                        'plaintext_body': 'template body.txt',
+                        'message_variation_id': None,
+                    },
+                },
+            },
+        }
+
+    @ddt.data(
+        (None, None, None),
+        ('', None, None),
+        ('campaign_id', 'campaign_id', None),
+        ('campaign_id:variation_id', 'campaign_id', 'variation_id'),
+    )
+    @ddt.unpack
+    def test_campaigns(self, campaign_setting, campaign_id, variation_id):
+        """If set, we should pass on the campaign identifiers"""
+        full_settings = {
+            'testmessage': campaign_setting,
+        }
+        with override_settings(ACE_CHANNEL_BRAZE_CAMPAIGNS=full_settings):
+            mock_post = self.deliver_email()
+        assert mock_post.call_args[1]['json']['campaign_id'] == campaign_id
+        assert mock_post.call_args[1]['json']['messages']['email']['message_variation_id'] == variation_id
+
+    def test_transactional(self):
+        """Transactional emails have different subscriber settings"""
+        mock_post = self.deliver_email(options={'transactional': True})
+        assert mock_post.call_args[1]['json']['recipient_subscription_state'] == 'all'
+
+    def test_from_address(self):
+        """Can set a from address in options"""
+        mock_post = self.deliver_email(options={'from_address': 'testing@example.com'})
+        assert mock_post.call_args[1]['json']['messages']['email']['from'] == 'testing@example.com'
+
+    def test_reply_to(self):
+        """Can set a reply-to address in options"""
+        mock_post = self.deliver_email(options={'reply_to': 'reply@example.com'})
+        assert mock_post.call_args[1]['json']['messages']['email']['reply_to'] == 'reply@example.com'
+
+    @ddt.data(0, None)
+    def test_lms_user_id_fallback(self, user_id):
+        """Use django instead if we can't find user id"""
+        with patch('edx_ace.channel.braze.DjangoEmailChannel') as mock_django:
+            mock_post = self.deliver_email(lms_user_id=user_id)
+
+        assert mock_post.call_count == 0
+        assert mock_django.call_count == 1
+
+    @ddt.data(
+        (400, FatalChannelDeliveryError),
+        (429, RecoverableChannelDeliveryError),
+        (500, RecoverableChannelDeliveryError),
+    )
+    @ddt.unpack
+    def test_status_raises(self, code, exception):
+        with self.assertRaisesRegex(exception, 'error will robinson'):
+            self.deliver_email(response_code=code, response_message='error will robinson')
+
+    @override_settings(ACE_CHANNEL_BRAZE_API_KEY='')
+    def test_disabled(self):
+        assert not self.channel.enabled()
+        with self.assertRaisesRegex(FatalChannelDeliveryError, 'disabled'):
+            self.deliver_email()

--- a/edx_ace/tests/channel/test_channel_helpers.py
+++ b/edx_ace/tests/channel/test_channel_helpers.py
@@ -29,7 +29,7 @@ class TestChannelMap(TestCase):
                 'key2': 'value2',
             },
             'recipient': Recipient(
-                username='me',
+                lms_user_id=123,
             )
         }
 

--- a/edx_ace/tests/channel/test_django_email.py
+++ b/edx_ace/tests/channel/test_django_email.py
@@ -23,7 +23,7 @@ class TestDjangoEmailChannel(TestCase):
             options={
                 'from_address': 'bulk@example.com',
             },
-            recipient=Recipient(username='Robot', email_address='mr@robot.io'),
+            recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
         )
 
         self.mock_rendered_message = Mock(
@@ -42,7 +42,7 @@ class TestDjangoEmailChannel(TestCase):
             app_label='testapp',
             name='testmessage',
             options={},
-            recipient=Recipient(username='Robot', email_address='mr@robot.io'),
+            recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
         )
 
         return render(channel, message)
@@ -74,7 +74,7 @@ class TestDjangoEmailChannel(TestCase):
             app_label='testapp',
             name='testmessage',
             options={},
-            recipient=Recipient(username='Robot', email_address='mr@robot.io'),
+            recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
         )
 
         with self.assertRaises(FatalChannelDeliveryError):
@@ -86,7 +86,7 @@ class TestDjangoEmailChannel(TestCase):
             app_label='testapp',
             name='testmessage',
             options={},
-            recipient=Recipient(username='Robot', email_address='mr@robot.io'),
+            recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
         )
 
         self.channel.deliver(message, self.mock_rendered_message)

--- a/edx_ace/tests/channel/test_file_email.py
+++ b/edx_ace/tests/channel/test_file_email.py
@@ -40,7 +40,7 @@ class TestFilesEmailChannel(TestCase):
                     'from_address': 'bulk@example.com',
                     PATH_OVERRIDE_KEY: f.name,
                 },
-                recipient=Recipient(username='Robot', email_address='mr@robot.io'),
+                recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
             )
 
             channel.deliver(message, rendered_message)

--- a/edx_ace/tests/channel/test_sailthru.py
+++ b/edx_ace/tests/channel/test_sailthru.py
@@ -2,10 +2,11 @@
 from unittest.mock import patch
 
 import ddt
+from edx_toggles.toggles.testutils import override_waffle_flag
 
 from django.test import TestCase, override_settings
 
-from edx_ace.channel.sailthru import SailthruEmailChannel
+from edx_ace.channel.sailthru import BRAZE_ROLLOUT_FLAG, SailthruEmailChannel
 from edx_ace.delivery import deliver
 from edx_ace.message import Message
 from edx_ace.presentation import render
@@ -23,7 +24,7 @@ class TestSailthruChannel(TestCase):
             app_label='testapp',
             name='testmessage',
             options={},
-            recipient=Recipient(username='Robot', email_address='mr@robot.io'),
+            recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
         )
 
         rendered_email = render(self.channel, message)
@@ -50,10 +51,32 @@ class TestSailthruChannel(TestCase):
             app_label='testapp',
             name='testmessage',
             options=message_options,
-            recipient=Recipient(username='Robot', email_address='mr@robot.io'),
+            recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
         )
         rendered_email = render(self.channel, message)
 
         with patch('edx_ace.channel.sailthru.SailthruClient.send') as mock_send:
             deliver(self.channel, rendered_email, message)
             self.assertEqual(mock_send.call_args_list[0][1]['options'], expected_options)
+
+    @override_settings(
+        ACE_CHANNEL_BRAZE_API_KEY='test-api-key',
+        ACE_CHANNEL_BRAZE_APP_ID='test-app-id',
+        ACE_CHANNEL_BRAZE_REST_ENDPOINT='rest.braze.com',
+        ACE_CHANNEL_SAILTHRU_DEBUG=False,
+    )
+    @ddt.data(True, False)
+    def test_braze_rollout_flag(self, enabled):
+        message = Message(
+            app_label='testapp',
+            name='testmessage',
+            recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
+        )
+        rendered_email = render(self.channel, message)
+
+        with patch('edx_ace.channel.sailthru.SailthruClient.send') as mock_send:
+            with patch('edx_ace.channel.sailthru.BrazeEmailChannel') as mock_braze:
+                with override_waffle_flag(BRAZE_ROLLOUT_FLAG, active=enabled):
+                    deliver(self.channel, rendered_email, message)
+                    assert mock_braze.call_count == (1 if enabled else 0)
+                    assert mock_send.call_count == (0 if enabled else 1)

--- a/edx_ace/tests/test_ace.py
+++ b/edx_ace/tests/test_ace.py
@@ -26,7 +26,7 @@ class TestAce(TestCase):
             tracker_image_sources=[],
         )
 
-        recipient = Recipient(username='testuser')
+        recipient = Recipient(lms_user_id=123)
         msg = Message(
             app_label='testapp',
             name='testmessage',
@@ -54,7 +54,7 @@ class TestAce(TestCase):
 
     @patch('edx_ace.ace.get_channel_for_message', side_effect=UnsupportedChannelError)
     def test_ace_send_unsupported_channel(self, *_args):
-        recipient = Recipient(username='testuser')
+        recipient = Recipient(lms_user_id=123)
         msg = Message(
             app_label='testapp',
             name='testmessage',

--- a/edx_ace/tests/test_delivery.py
+++ b/edx_ace/tests/test_delivery.py
@@ -22,7 +22,7 @@ class TestDelivery(TestCase):  # pylint: disable=missing-class-docstring
             channel_type=ChannelType.EMAIL
         )
         self.recipient = Recipient(
-            username=str(sentinel.username)
+            lms_user_id=123
         )
         self.message = Message(
             app_label=str(sentinel.app_label),

--- a/edx_ace/tests/test_message.py
+++ b/edx_ace/tests/test_message.py
@@ -34,7 +34,7 @@ msg = st.builds(
     ),
     recipient=st.builds(
         Recipient,
-        username=st.text(),
+        lms_user_id=st.integers(min_value=1),
     ),
     send_uuid=st.one_of(st.uuids(), st.none()),
 )
@@ -56,7 +56,7 @@ class TestMessage(TestCase):
                 'key2': 'value2',
             },
             'recipient': Recipient(
-                username='me',
+                lms_user_id=123,
             )
         }
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,9 +2,9 @@
 
 -c constraints.txt
 Django>=2.2,<2.3                  # Web application framework
+edx-toggles
 python-dateutil                   # Python Date Utilities
 attrs>=17.2.0                     # Attributes without boilerplate
 sailthru-client==2.2.3
 six
 stevedore>=1.10.0
-

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
     ],
     entry_points={
         'openedx.ace.channel': [
+            'braze_email = edx_ace.channel.braze:BrazeEmailChannel',
             'sailthru_email = edx_ace.channel.sailthru:SailthruEmailChannel',
             'file_email = edx_ace.channel.file:FileEmailChannel',
             'django_email = edx_ace.channel.django_email:DjangoEmailChannel',

--- a/test_settings.py
+++ b/test_settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'edx_ace',
+    'waffle',
 )
 
 LOCALE_PATHS = [


### PR DESCRIPTION
This release also changes the Recipient class, to take an lms_user_id instead of username required argument.

https://openedx.atlassian.net/browse/AA-489