### PR TITLE
feat: add ACE_CHANNEL_BRAZE_FROM_EMAIL setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.1.0] - 2021-03-26
+~~~~~~~~~~~~~~~~~~~~
+
+* Braze: Add ACE_CHANNEL_BRAZE_FROM_EMAIL setting to override the normal from address
 * Sailthru: Remove Braze rollout waffle flag
 
 [1.0.1] - 2021-03-15

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 default_app_config = 'edx_ace.apps.EdxAceConfig'
 

--- a/edx_ace/tests/channel/test_braze.py
+++ b/edx_ace/tests/channel/test_braze.py
@@ -116,10 +116,16 @@ class TestBrazeChannel(TestCase):
         mock_post = self.deliver_email(options={'transactional': True})
         assert mock_post.call_args[1]['json']['recipient_subscription_state'] == 'all'
 
-    def test_from_address(self):
-        """Can set a from address in options"""
+    def test_from_address_in_message(self):
+        """Can set a from address in message options"""
         mock_post = self.deliver_email(options={'from_address': 'testing@example.com'})
         assert mock_post.call_args[1]['json']['messages']['email']['from'] == 'testing@example.com'
+
+    @override_settings(ACE_CHANNEL_BRAZE_FROM_EMAIL='settings@example.com')
+    def test_from_address_in_settings(self):
+        """Can set a from address in settings, which will be preferred over the message options"""
+        mock_post = self.deliver_email(options={'from_address': 'message@example.com'})
+        assert mock_post.call_args[1]['json']['messages']['email']['from'] == 'settings@example.com'
 
     def test_reply_to(self):
         """Can set a reply-to address in options"""


### PR DESCRIPTION
This setting will override a message's normal from address. Braze has specific constraints, where it only allows sending emails from whitelisted from addresses.

I went this way, rather than adding a more generic `ACE_CHANNEL_TRANSACTIONAL_FROM_EMAIL`  or similar, because (A) that would be flipping defaults for open edx (B) I felt like this was a bit more of a Braze backend specific constraint, where it refuses to allow non-whitelisted emails.