### PR TITLE
feat: braze can now force delivery of some transactional emails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,16 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.3.0] - 2021-08-16
+~~~~~~~~~~~~~~~~~~~~
+
+* New channel method ``handles_delivery_for_message`` for allowing a default channel
+  to claim a message, even if it would normally be delivered to the configured
+  transactional channel.
+* Braze: Will handle any message defined in ACE_CHANNEL_BRAZE_CAMPAIGNS (using the
+  above new feature) to steal campaign messages from the transactional channel as
+  needed.
+
 [1.2.0] - 2021-07-16
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -5,7 +5,7 @@ sending messages to users.
 :mod:`edx_ace` exports the typical set of functions and classes needed to use
 ACE.
 """
-# -*- coding: utf-8 -*-
+
 from .ace import send
 from .channel import Channel, ChannelType
 from .message import Message, MessageType
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 default_app_config = 'edx_ace.apps.EdxAceConfig'
 

--- a/edx_ace/channel/__init__.py
+++ b/edx_ace/channel/__init__.py
@@ -62,6 +62,17 @@ class Channel(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
+    def handles_delivery_for_message(self, message):  # pylint: disable=unused-argument
+        """
+        Returns true if this channel specifically wants to handle this message, outside normal channel delivery rules.
+
+        For example, say you use a django transactional email channel, but with a default channel of braze.
+        Then if the braze channel is configured with a campaign for a certain transactional message id specifically, it
+        will claim that message via this method and end up delivering it via braze instead of the normal transactional
+        django channel.
+        """
+        return False
+
 
 class ChannelMap:
     """
@@ -162,12 +173,24 @@ def get_channel_for_message(channel_type, message):
 
     if channel_type == ChannelType.EMAIL:
         if message.options.get('transactional'):
-            channel_name = settings.ACE_CHANNEL_TRANSACTIONAL_EMAIL
+            channel_names = [settings.ACE_CHANNEL_TRANSACTIONAL_EMAIL, settings.ACE_CHANNEL_DEFAULT_EMAIL]
         else:
-            channel_name = settings.ACE_CHANNEL_DEFAULT_EMAIL
+            channel_names = [settings.ACE_CHANNEL_DEFAULT_EMAIL]
+
         try:
-            return channels_map.get_channel_by_name(channel_type, channel_name)
+            possible_channels = [
+                channels_map.get_channel_by_name(channel_type, channel_name)
+                for channel_name in channel_names
+            ]
         except KeyError:
-            pass
+            return channels_map.get_default_channel(channel_type)
+
+        # First see if any channel specifically demands to deliver this message
+        for channel in possible_channels:
+            if channel.handles_delivery_for_message(message):
+                return channel
+
+        # Else the normal path: use the preferred channel for this message type
+        return possible_channels[0]
 
     return channels_map.get_default_channel(channel_type)

--- a/edx_ace/channel/braze.py
+++ b/edx_ace/channel/braze.py
@@ -150,6 +150,12 @@ class BrazeEmailChannel(EmailChannelMixin, Channel):
             logger.debug('Failed to send to Braze: %s', message)
             self._handle_error_response(response, message, exc)
 
+    def handles_delivery_for_message(self, message):
+        # If we have a campaign configured for this message, let's deliver it ourselves, even if it's a transactional
+        # message. Presumably that campaign is set up to ignore global delivery caps so that we don't drop such a
+        # transactional message on the floor. This kind of configuration could be done to get nice email metrics.
+        return self._campaign_id(message.name) is not None
+
     def _handle_error_response(self, response, message, exception):
         """
         Handle an error response from Braze, either by retrying or failing

--- a/edx_ace/tests/channel/test_channel_helpers.py
+++ b/edx_ace/tests/channel/test_channel_helpers.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 from django.test import TestCase, override_settings
 
 from edx_ace.channel import ChannelMap, ChannelType, get_channel_for_message
+from edx_ace.channel.braze import BrazeEmailChannel
 from edx_ace.channel.file import FileEmailChannel
-from edx_ace.channel.sailthru import SailthruEmailChannel
 from edx_ace.errors import UnsupportedChannelError
 from edx_ace.message import Message
 from edx_ace.recipient import Recipient
@@ -33,33 +33,45 @@ class TestChannelMap(TestCase):
             )
         }
 
+    @override_settings(
+        ACE_CHANNEL_BRAZE_CAMPAIGNS={
+            'campaign_msg': 'campaign_id:variation_id',
+        },
+        ACE_CHANNEL_DEFAULT_EMAIL='braze_email',
+        ACE_CHANNEL_TRANSACTIONAL_EMAIL='file_email',
+    )
     def test_get_channel_for_message(self):
         channel_map = ChannelMap([
-            ['file_email', FileEmailChannel],
-            ['sailthru_email', SailthruEmailChannel],
+            ['file_email', FileEmailChannel()],
+            ['braze_email', BrazeEmailChannel()],
         ])
 
         transactional_msg = Message(options={'transactional': True}, **self.msg_kwargs)
         info_msg = Message(options={}, **self.msg_kwargs)
 
+        # A transactional message which the default channel wants to handle and thus should be directed appropriately
+        transactional_campaign_msg = Message(options={'transactional': True}, **self.msg_kwargs)
+        transactional_campaign_msg.name = 'campaign_msg'
+
         with patch('edx_ace.channel.channels', return_value=channel_map):
-            assert get_channel_for_message(ChannelType.EMAIL, transactional_msg) is FileEmailChannel
-            assert get_channel_for_message(ChannelType.EMAIL, info_msg) is SailthruEmailChannel
+            assert isinstance(get_channel_for_message(ChannelType.EMAIL, transactional_msg), FileEmailChannel)
+            assert isinstance(get_channel_for_message(ChannelType.EMAIL, transactional_campaign_msg), BrazeEmailChannel)
+            assert isinstance(get_channel_for_message(ChannelType.EMAIL, info_msg), BrazeEmailChannel)
 
             with self.assertRaises(UnsupportedChannelError):
                 assert get_channel_for_message(ChannelType.PUSH, transactional_msg)
 
     @override_settings(
-        ACE_CHANNEL_DEFAULT_EMAIL='sailthru_email',
+        ACE_CHANNEL_DEFAULT_EMAIL='braze_email',
         ACE_CHANNEL_TRANSACTIONAL_EMAIL='file_email',
     )
     def test_default_channel(self):
         channel_map = ChannelMap([
-            ['sailthru', SailthruEmailChannel],
+            ['braze', BrazeEmailChannel()],
         ])
 
         message = Message(options={'transactional': True}, **self.msg_kwargs)
 
         with patch('edx_ace.channel.channels', return_value=channel_map):
             channel = get_channel_for_message(ChannelType.EMAIL, message)
-            assert channel is SailthruEmailChannel
+            assert isinstance(channel, BrazeEmailChannel)


### PR DESCRIPTION
Before, all transactional emails would normally go through a non-external service like AWS SES or something. Now, the Braze channel will notice if you configure a campaign ID even for a normally-transactional email, and it will deliver it for you.

This is useful if you want to gather metrics for a transactional email. Just be sure to turn off global limit handling for that campaign.

https://openedx.atlassian.net/browse/AA-951