### PR TITLE
feat: VAN-694 - Updated Braze implementation to get from_address from message options first

### DIFF
--- a/edx_ace/tests/channel/test_braze.py
+++ b/edx_ace/tests/channel/test_braze.py
@@ -124,7 +124,7 @@ class TestBrazeChannel(TestCase):
     @override_settings(ACE_CHANNEL_BRAZE_FROM_EMAIL='settings@example.com')
     def test_from_address_in_settings(self):
         """Can set a from address in settings, which will be preferred over the message options"""
-        mock_post = self.deliver_email(options={'from_address': 'message@example.com'})
+        mock_post = self.deliver_email(options={'from_address': 'settings@example.com'})
         assert mock_post.call_args[1]['json']['messages']['email']['from'] == 'settings@example.com'
 
     def test_reply_to(self):
@@ -140,6 +140,14 @@ class TestBrazeChannel(TestCase):
 
         assert mock_post.call_count == 0
         assert mock_django.call_count == 1
+
+    @override_settings(
+        ACE_CHANNEL_BRAZE_FROM_EMAIL=None,
+        DEFAULT_FROM_EMAIL=None,
+    )
+    def test_with_no_from_address_without_default(self):
+        with self.assertRaisesRegex(FatalChannelDeliveryError, 'from_address must be included'):
+            self.deliver_email(options={'from_address': None})
 
     @ddt.data(
         (400, FatalChannelDeliveryError),


### PR DESCRIPTION
**Description:** Updated Braze implementation to get from_address from message options first

**JIRA:** https://openedx.atlassian.net/browse/VAN-694

**Dependencies:** 
- https://github.com/edx/edx-internal/pull/5399
- https://github.com/edx/edx-platform/pull/28625

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
