### PR TITLE
feat: add capability to omit unsubscribe links in braze

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.4.0] - 2021-11-08
+~~~~~~~~~~~~~~~~~~~~
+
+* Deprecate the action_links property
+* Add a get_action_links method and template tag to allow passing arguments to action links
+
 [1.3.1] - 2021-08-17
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '1.3.1'
+__version__ = '1.4.0'
 
 default_app_config = 'edx_ace.apps.EdxAceConfig'
 

--- a/edx_ace/channel/braze.py
+++ b/edx_ace/channel/braze.py
@@ -3,6 +3,7 @@
 """
 import logging
 import random
+import warnings
 from datetime import timedelta
 from gettext import gettext as _
 
@@ -83,10 +84,25 @@ class BrazeEmailChannel(EmailChannelMixin, Channel):
 
     @property
     def action_links(self):
-        """Provides list of action links, called by templates directly"""
-        return [
-            ('{{${set_user_to_unsubscribed_url}}}', _('Unsubscribe from this list')),
-        ]
+        """
+        This method is now deprecated in favor of get_action_links,
+        but will continue to work for the time being as it calls get_action_links under the hood.
+        """
+        warnings.warn("This method is now deprecated in favor of get_action_links")
+        return self.get_action_links()
+
+    def get_action_links(self, **kwargs):
+        """
+        Provides list of action links, called by templates directly.
+        Supported kwargs:
+            omit_unsubscribe_link (bool): Removes the unsubscribe link from the email.
+                DO NOT send emails with no unsubscribe link unless you are sure it will not violate the CANSPAM act.
+        """
+        omit_unsubscribe_link = kwargs.get('omit_unsubscribe_link')
+        action_links = []
+        if not omit_unsubscribe_link:
+            action_links += [('{{${set_user_to_unsubscribed_url}}}', _('Unsubscribe from this list'))]
+        return action_links
 
     @property
     def tracker_image_sources(self):

--- a/edx_ace/channel/sailthru.py
+++ b/edx_ace/channel/sailthru.py
@@ -5,6 +5,7 @@ channel for ACE.
 import logging
 import random
 import textwrap
+import warnings
 from datetime import datetime, timedelta
 from enum import Enum, IntEnum
 from gettext import gettext as _
@@ -148,12 +149,28 @@ class SailthruEmailChannel(Channel):
 
     @property
     def action_links(self):
-        """Provides list of action links, called by templates directly"""
+        """
+        This method is now deprecated in favor of get_action_links,
+        but will continue to work for the time being as it calls get_action_links under the hood.
+        """
+        warnings.warn("This method is now deprecated in favor of get_action_links")
+        return self.get_action_links()
+
+    def get_action_links(self, **kwargs):
+        """
+        Provides list of action links, called by templates directly.
+        Supported kwargs:
+            omit_unsubscribe_link (bool): Removes the unsubscribe link from the email.
+            DO NOT send emails with no unsubscribe link unless you are sure it will not violate the CANSPAM act.
+        """
         # Note that these variables are evaluated by Sailthru, not the Django template engine
-        return [
+        omit_unsubscribe_link = kwargs.get('omit_unsubscribe_link')
+        action_links_list = [
             ('{view_url}', _('View on Web')),
-            ('{optout_confirm_url}', _('Unsubscribe from this list')),
         ]
+        if not omit_unsubscribe_link:
+            action_links_list.append(('{optout_confirm_url}', _('Unsubscribe from this list')),)
+        return action_links_list
 
     @property
     def tracker_image_sources(self):

--- a/edx_ace/templatetags/acetags.py
+++ b/edx_ace/templatetags/acetags.py
@@ -1,0 +1,16 @@
+'''
+edx-ace template tags
+'''
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def get_action_links(context, channel, omit_unsubscribe_link=False):
+    """
+    Retrieve the action links for the channel and pass the omit_unsubscribe_link argument
+    """
+    if getattr(channel, 'get_action_links', None):
+        return channel.get_action_links(omit_unsubscribe_link=context.get('omit_unsubscribe_link'))
+    return []

--- a/edx_ace/tests/channel/test_sailthru.py
+++ b/edx_ace/tests/channel/test_sailthru.py
@@ -70,3 +70,22 @@ class TestSailthruChannel(TestCase):
 
         with self.assertRaisesRegex(InvalidMessageError, 'No email address'):
             deliver(self.channel, rendered_email, message)
+
+    def test_get_action_links_omit_unsubscribe_link(self):
+        """Some emails use a setting that omits the unsubscribe action link"""
+        assert len(self.channel.action_links) == 2
+        assert len(self.channel.get_action_links(omit_unsubscribe_link=True)) == 1
+
+    def test_email_omits_unsubscribe_link(self):
+        """Basic email send, no special settings"""
+        message = Message(
+            app_label='testapp',
+            name='testmessage',
+            options={},
+            context={'omit_unsubscribe_link': True},
+            recipient=Recipient(lms_user_id=123, email_address='mr@robot.io'),
+        )
+
+        rendered_email = render(self.channel, message)
+
+        assert '{optout_confirm_url}' not in rendered_email.body_html

--- a/edx_ace/tests/test_ace.py
+++ b/edx_ace/tests/test_ace.py
@@ -23,6 +23,7 @@ class TestAce(TestCase):
         mock_channel = Mock(
             channel_type=ChannelType.EMAIL,
             action_links=[],
+            get_action_links=[],
             tracker_image_sources=[],
         )
 

--- a/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/body.html
+++ b/edx_ace/tests/test_templates/testapp/edx_ace/testmessage/email/body.html
@@ -1,14 +1,14 @@
 template body.html
-
+{% load acetags %}
 {% for image_source in channel.tracker_image_sources %}
     <img src="{{ image_source }}" alt="" role="presentation" aria-hidden="true" />
 {% endfor %}
-
-{% if channel.action_links %}
+{% get_action_links channel omit_unsubscribe_link=omit_unsubscribe_link as action_links %}
+{% if action_links %}
 <tr>
     <!-- Actions -->
     <td style="padding-bottom: 20px;">
-        {% for href, title in channel.action_links %}
+        {% for href, title in action_links %}
             <p>
                 <a href="{{ href }}" style="color: #960909">
                     <font color="#960909"><b>{{ title }}</b></font>


### PR DESCRIPTION
For the goal reminder email feature (AA-909) we have our own custom unsubscribe link and we need the ability to omit the unsubscribe link added by edx-ace.
This PR adds a setting that will omit this unsubscribe link that is currently added through the action_links method
I'm open to other approaches for this as well

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings) <- which documentation?
- [x] Commits are squashed

**Post merge:**
- [x] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
