### PR TITLE
feat: AA-1127: Adds ability to override Braze frequency caps when sen…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.4.1] - 2021-12-06
+~~~~~~~~~~~~~~~~~~~~
+
+* Adds in the ability to override frequency caps for Braze emails. Can be accessed via
+  Message options using the key ``override_frequency_capping``. All emails containing the
+  ``transactional`` Message option will also override frequency caps.
+
 [1.4.0] - 2021-11-08
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 default_app_config = 'edx_ace.apps.EdxAceConfig'
 

--- a/edx_ace/channel/braze.py
+++ b/edx_ace/channel/braze.py
@@ -122,6 +122,7 @@ class BrazeEmailChannel(EmailChannelMixin, Channel):
             return
 
         transactional = message.options.get('transactional', False)
+        override_frequency_capping = message.options.get('override_frequency_capping', transactional)
         body_html = self.make_simple_html_template(rendered_message.head_html, rendered_message.body_html)
 
         # Allow our settings to override the from address, because Braze requires specific configured from addresses,
@@ -141,6 +142,7 @@ class BrazeEmailChannel(EmailChannelMixin, Channel):
                 'external_user_ids': [str(message.recipient.lms_user_id)],
                 'recipient_subscription_state': 'all' if transactional else 'subscribed',
                 'campaign_id': self._campaign_id(message.name),
+                'override_frequency_capping': override_frequency_capping,
                 'messages': {
                     'email': {
                         'app_id': getattr(settings, self._APP_ID_SETTING),

--- a/edx_ace/tests/channel/test_braze.py
+++ b/edx_ace/tests/channel/test_braze.py
@@ -60,6 +60,7 @@ class TestBrazeChannel(TestCase):
                 'external_user_ids': ['123'],
                 'recipient_subscription_state': 'subscribed',
                 'campaign_id': None,
+                'override_frequency_capping': False,
                 'messages': {
                     'email': {
                         'app_id': 'test-app-id',
@@ -116,6 +117,7 @@ class TestBrazeChannel(TestCase):
         """Transactional emails have different subscriber settings"""
         mock_post = self.deliver_email(options={'transactional': True})
         assert mock_post.call_args[1]['json']['recipient_subscription_state'] == 'all'
+        assert mock_post.call_args[1]['json']['override_frequency_capping']
 
     def test_get_action_links_omit_unsubscribe_link(self):
         """Some emails use a setting that omits the unsubscribe action link"""


### PR DESCRIPTION
…ding emails

**Description:** Braze API based campaigns are still subject to the global capping
rules defined in Braze. In order to get around this, you can specifically state
the email will override those rules. Now edx-ace supports that capability.

**JIRA:** [Link to JIRA ticket](https://openedx.atlassian.net/browse/AA-1127)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
