### PR TITLE
fix: Update code coverage target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         enabled: yes
-        target: auto
+        target: 93
     patch:
       default:
         enabled: yes


### PR DESCRIPTION
**Description:** 
 Change the codecov settings to 93% to allow small reductions in coverage as long it doesn't go below the specified target.


### [VAN-1198](https://2u-internal.atlassian.net/browse/VAN-1189)
