### PR TITLE
build: remove unnecessary codecov package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Run Coverage
       if: matrix.python-version == '3.8' && matrix.toxenv=='django32'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery==0.2          # Makes tox aware of requirements file changes; restricted by https://github.com/signalpillar/tox-battery/issues/6

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==7.2.3
     # via codecov
 distlib==0.3.6


### PR DESCRIPTION
and use latest codecov GHA

Context: https://about.codecov.io/blog/message-regarding-the-pypi-package/

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green