### PR TITLE
fix: remove tox-battery and update tox

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,4 +3,3 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-battery==0.2          # Makes tox aware of requirements file changes; restricted by https://github.com/signalpillar/tox-battery/issues/6

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ coverage==7.2.3
     # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.11.0
+filelock==3.13.1
     # via
     #   tox
     #   virtualenv
@@ -32,13 +32,10 @@ six==1.16.0
     # via tox
 tomli==2.0.1
     # via tox
-tox==3.28.0
+tox==4.11.4
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.2
-    # via -r requirements/ci.in
 urllib3==1.26.15
     # via requests
 virtualenv==20.21.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,39 +4,35 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-coverage==7.2.3
-    # via codecov
-distlib==0.3.6
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
+distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.2
+    # via
+    #   pyproject-api
+    #   tox
+platformdirs==4.1.0
+    # via
+    #   tox
+    #   virtualenv
+pluggy==1.3.0
     # via tox
-platformdirs==3.2.0
-    # via virtualenv
-pluggy==1.0.0
-    # via tox
-py==1.11.0
-    # via tox
-requests==2.28.2
-    # via codecov
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
-    # via tox
-tox==4.11.4
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
-virtualenv==20.21.0
+    #   pyproject-api
+    #   tox
+tox==4.11.4
+    # via -r requirements/ci.in
+virtualenv==20.25.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,7 +55,7 @@ edx-lint==5.3.4
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.in
-filelock==3.11.0
+filelock==3.13.1
     # via
     #   tox
     #   virtualenv
@@ -200,7 +200,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.7
     # via pylint
-tox==3.28.0
+tox==4.11.4
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/dev.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,27 +4,27 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-astroid==2.15.2
+astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
+attrs==23.1.0
     # via -r requirements/base.in
-bleach==6.0.0
-    # via readme-renderer
-build==0.10.0
+build==1.0.3
     # via pip-tools
-certifi==2022.12.7
+cachetools==5.3.2
+    # via tox
+certifi==2023.11.17
     # via requests
-cffi==1.15.1
-    # via cryptography
-chardet==5.1.0
-    # via diff-cover
-charset-normalizer==3.1.0
+chardet==5.2.0
+    # via
+    #   diff-cover
+    #   tox
+charset-normalizer==3.3.2
     # via requests
-click==8.1.3
+click==8.1.7
     # via
     #   click-log
     #   code-annotations
@@ -32,26 +32,26 @@ click==8.1.3
     #   pip-tools
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.3.0
+code-annotations==1.5.0
     # via edx-lint
-cryptography==40.0.1
-    # via secretstorage
-diff-cover==7.5.0
+colorama==0.4.6
+    # via tox
+diff-cover==8.0.1
     # via -r requirements/dev.in
-dill==0.3.6
+dill==0.3.7
     # via pylint
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
-django==3.2.18
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   edx-i18n-tools
-docutils==0.19
+docutils==0.20.1
     # via readme-renderer
-edx-i18n-tools==0.9.2
+edx-i18n-tools==1.3.0
     # via -r requirements/dev.in
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.in
@@ -59,78 +59,75 @@ filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-idna==3.4
+idna==3.6
     # via requests
-importlib-metadata==6.3.0
+importlib-metadata==7.0.0
     # via
+    #   build
     #   keyring
     #   twine
-importlib-resources==5.12.0
+importlib-resources==6.1.1
     # via keyring
 isort==5.12.0
     # via
     #   -r requirements/quality.in
     #   pylint
-jaraco-classes==3.2.3
+jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   code-annotations
     #   diff-cover
-keyring==23.13.1
+keyring==24.3.0
     # via twine
-lazy-object-proxy==1.9.0
-    # via astroid
-markdown-it-py==2.2.0
+lxml==4.9.3
+    # via edx-i18n-tools
+markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==9.1.0
+more-itertools==10.1.0
     # via jaraco-classes
-packaging==23.0
+nh3==0.2.15
+    # via readme-renderer
+packaging==23.2
     # via
     #   build
+    #   pyproject-api
     #   tox
-path==16.6.0
+path==16.9.0
     # via edx-i18n-tools
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
-pip-tools==6.13.0
+pip-tools==7.3.0
     # via -r requirements/dev.in
 pkginfo==1.9.6
     # via twine
-platformdirs==3.2.0
+platformdirs==4.1.0
     # via
     #   pylint
+    #   tox
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.3.0
     # via
     #   diff-cover
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-py==1.11.0
-    # via tox
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.14.0
+pygments==2.17.2
     # via
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==2.17.2
+pylint==3.0.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -138,55 +135,53 @@ pylint==2.17.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
+pyproject-api==1.6.1
+    # via tox
 pyproject-hooks==1.0.0
     # via build
 python-dateutil==2.8.2
     # via -r requirements/base.in
 python-slugify==8.0.1
     # via code-annotations
-pytz==2023.3
+pytz==2023.3.post1
     # via django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   code-annotations
     #   edx-i18n-tools
-readme-renderer==37.3
+readme-renderer==42.0
     # via twine
-requests==2.28.2
+requests==2.31.0
     # via
     #   requests-toolbelt
     #   sailthru-client
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.3
+rich==13.7.0
     # via twine
 sailthru-client==2.2.3
     # via -r requirements/base.in
-secretstorage==3.3.3
-    # via keyring
-simplejson==3.19.1
+simplejson==3.19.2
     # via sailthru-client
 six==1.16.0
     # via
     #   -r requirements/base.in
-    #   bleach
     #   edx-lint
     #   python-dateutil
-    #   tox
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/base.in
     #   code-annotations
@@ -195,37 +190,34 @@ text-unidecode==1.3
 tomli==2.0.1
     # via
     #   build
+    #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   tox
-tomlkit==0.11.7
+tomlkit==0.12.3
     # via pylint
 tox==4.11.4
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/dev.in
+    # via -r requirements/dev.in
 twine==4.0.2
     # via -r requirements/dev.in
-typing-extensions==4.5.0
+typing-extensions==4.8.0
     # via
+    #   asgiref
     #   astroid
     #   pylint
     #   rich
-urllib3==1.26.15
+urllib3==2.1.0
     # via
     #   requests
     #   twine
-virtualenv==20.21.0
+virtualenv==20.25.0
     # via tox
-webencodings==0.5.1
-    # via bleach
-wheel==0.40.0
+wheel==0.42.0
     # via
     #   -r requirements/dev.in
     #   pip-tools
-wrapt==1.15.0
-    # via astroid
-zipp==3.15.0
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,27 +8,21 @@ accessible-pygments==0.0.4
     # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-attrs==22.2.0
+attrs==23.1.0
     # via -r requirements/base.in
-babel==2.12.1
+babel==2.13.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
-bleach==6.0.0
-    # via readme-renderer
-certifi==2022.12.7
+certifi==2023.11.17
     # via requests
-cffi==1.15.1
-    # via cryptography
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via requests
-cryptography==40.0.1
-    # via secretstorage
-django==3.2.18
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -41,48 +35,44 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-idna==3.4
+idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.3.0
+importlib-metadata==7.0.0
     # via
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==5.12.0
+importlib-resources==6.1.1
     # via keyring
-jaraco-classes==3.2.3
+jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.13.1
+keyring==24.3.0
     # via twine
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==9.1.0
+more-itertools==10.1.0
     # via jaraco-classes
-packaging==23.0
+nh3==0.2.15
+    # via readme-renderer
+packaging==23.2
     # via
     #   pydata-sphinx-theme
     #   sphinx
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 pkginfo==1.9.6
     # via twine
-pycparser==2.21
-    # via cffi
-pydata-sphinx-theme==0.13.3
+pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
-pygments==2.14.0
+pygments==2.17.2
     # via
     #   accessible-pygments
     #   doc8
@@ -92,46 +82,42 @@ pygments==2.14.0
     #   sphinx
 python-dateutil==2.8.2
     # via -r requirements/base.in
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   babel
     #   django
-readme-renderer==37.3
+readme-renderer==42.0
     # via
     #   -r requirements/doc.in
     #   twine
-requests==2.28.2
+requests==2.31.0
     # via
     #   requests-toolbelt
     #   sailthru-client
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via twine
 restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.3.3
+rich==13.7.0
     # via twine
 sailthru-client==2.2.3
     # via -r requirements/base.in
-secretstorage==3.3.3
-    # via keyring
-simplejson==3.19.1
+simplejson==3.19.2
     # via sailthru-client
 six==1.16.0
     # via
     #   -r requirements/base.in
-    #   bleach
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.4
+soupsieve==2.5
     # via beautifulsoup4
-sphinx==5.3.0
+sphinx==6.2.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
@@ -149,9 +135,9 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/base.in
     #   doc8
@@ -159,17 +145,16 @@ tomli==2.0.1
     # via doc8
 twine==4.0.2
     # via -r requirements/doc.in
-typing-extensions==4.5.0
+typing-extensions==4.8.0
     # via
+    #   asgiref
     #   pydata-sphinx-theme
     #   rich
-urllib3==1.26.15
+urllib3==2.1.0
     # via
     #   requests
     #   twine
-webencodings==0.5.1
-    # via bleach
-zipp==3.15.0
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,20 +4,27 @@
 #
 #    make upgrade
 #
-build==0.10.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via pip-tools
-packaging==23.0
+importlib-metadata==7.0.0
     # via build
-pip-tools==6.13.0
+packaging==23.2
+    # via build
+pip-tools==7.3.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
-    # via build
-wheel==0.40.0
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
+wheel==0.42.0
     # via pip-tools
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.40.0
+wheel==0.42.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.3.1
     # via -r requirements/pip.in
-setuptools==67.6.1
+setuptools==69.0.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,22 +4,22 @@
 #
 #    make upgrade
 #
-astroid==2.15.2
+astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
-click==8.1.3
+click==8.1.7
     # via
     #   click-log
     #   code-annotations
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.3.0
+code-annotations==1.5.0
     # via edx-lint
-dill==0.3.6
+dill==0.3.7
     # via pylint
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/quality.in
 isort==5.12.0
     # via
@@ -27,21 +27,19 @@ isort==5.12.0
     #   pylint
 jinja2==3.1.2
     # via code-annotations
-lazy-object-proxy==1.9.0
-    # via astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
-platformdirs==3.2.0
+platformdirs==4.1.0
     # via pylint
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.2
+pylint==3.0.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -49,31 +47,29 @@ pylint==2.17.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
 python-slugify==8.0.1
     # via code-annotations
-pyyaml==6.0
+pyyaml==6.0.1
     # via code-annotations
 six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-stevedore==5.0.0
+stevedore==5.1.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
 tomli==2.0.1
     # via pylint
-tomlkit==0.11.7
+tomlkit==0.12.3
     # via pylint
-typing-extensions==4.5.0
+typing-extensions==4.8.0
     # via
     #   astroid
     #   pylint
-wrapt==1.15.0
-    # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,80 +4,82 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   -r requirements/base.in
     #   hypothesis
-certifi==2022.12.7
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via requests
-coverage[toml]==7.2.3
-    # via pytest-cov
-ddt==1.6.0
+coverage[toml]==7.3.2
+    # via
+    #   coverage
+    #   pytest-cov
+ddt==1.7.0
     # via -r requirements/test.in
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
-exceptiongroup==1.1.1
+exceptiongroup==1.2.0
     # via
     #   hypothesis
     #   pytest
-hypothesis[pytz]==6.71.0
+hypothesis[pytz]==6.91.1
     # via
     #   -r requirements/test.in
     #   hypothesis-pytest
 hypothesis-pytest==0.19.0
     # via -r requirements/test.in
-idna==3.4
+idna==3.6
     # via requests
-importlib-metadata==6.3.0
+importlib-metadata==7.0.0
     # via pytest-randomly
 iniconfig==2.0.0
     # via pytest
-jedi==0.18.2
+jedi==0.19.1
     # via pudb
-mock==5.0.1
+mock==5.1.0
     # via -r requirements/test.in
-packaging==23.0
+packaging==23.2
     # via
     #   pudb
     #   pytest
 parso==0.8.3
     # via jedi
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
-pudb==2022.1.3
+pudb==2023.1
     # via -r requirements/test.in
-pygments==2.14.0
+pygments==2.17.2
     # via pudb
-pytest==7.3.0
+pytest==7.4.3
     # via
     #   hypothesis-pytest
     #   pytest-cov
     #   pytest-django
     #   pytest-randomly
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-django==4.5.2
+pytest-django==4.7.0
     # via -r requirements/test.in
-pytest-randomly==3.12.0
+pytest-randomly==3.15.0
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via -r requirements/base.in
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   django
     #   hypothesis
-requests==2.28.2
+requests==2.31.0
     # via sailthru-client
 sailthru-client==2.2.3
     # via -r requirements/base.in
-simplejson==3.19.1
+simplejson==3.19.2
     # via sailthru-client
 six==1.16.0
     # via
@@ -85,21 +87,23 @@ six==1.16.0
     #   python-dateutil
 sortedcontainers==2.4.0
     # via hypothesis
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-stevedore==5.0.0
+stevedore==5.1.0
     # via -r requirements/base.in
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.15
+typing-extensions==4.8.0
+    # via asgiref
+urllib3==2.1.0
     # via requests
-urwid==2.1.2
+urwid==2.3.4
     # via
     #   pudb
     #   urwid-readline
 urwid-readline==0.13
     # via pudb
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata


### PR DESCRIPTION
## Description
- Remove `tox-battery` from requirements since it is not needed anymore with `tox>4`. 
- Updated `tox` to v4.