### PR TITLE
feat: added support for headers in DjangoEmailChannel

### DIFF
--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '1.9.0'
+__version__ = '1.9.1'
 
 
 __all__ = [

--- a/edx_ace/channel/django_email.py
+++ b/edx_ace/channel/django_email.py
@@ -62,6 +62,7 @@ class DjangoEmailChannel(EmailChannelMixin, Channel):
                 from_email=from_address,
                 to=[message.recipient.email_address],
                 reply_to=reply_to,
+                headers=message.headers,
             )
 
             mail.attach_alternative(rendered_template, 'text/html')

--- a/edx_ace/message.py
+++ b/edx_ace/message.py
@@ -73,6 +73,9 @@ class Message(MessageAttributeSerializationMixin, metaclass=ABCMeta):
         default=None
     )
     options = attr.ib()
+
+    # headers are only supported for DjangoEmailChannel
+    headers = attr.ib()
     language = attr.ib(default=None)
     log_level = attr.ib(default=None)
 
@@ -82,6 +85,10 @@ class Message(MessageAttributeSerializationMixin, metaclass=ABCMeta):
 
     @options.default
     def default_options_value(self):
+        return {}
+
+    @headers.default
+    def default_headers_value(self):
         return {}
 
     @uuid.default


### PR DESCRIPTION
Added support to add email headers for email in DjangoEmailChannel

Ticket: [INF-1430](https://2u-internal.atlassian.net/browse/INF-1430)