### PR TITLE
feat: changed message object to dictionary when sending ACE_MESSAGE_SENT signal

### DIFF
--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '1.11.1'
+__version__ = '1.11.2'
 
 
 __all__ = [

--- a/edx_ace/delivery.py
+++ b/edx_ace/delivery.py
@@ -10,8 +10,8 @@ import time
 from django.conf import settings
 
 from edx_ace.errors import RecoverableChannelDeliveryError
-from edx_ace.signals import ACE_MESSAGE_SENT
 from edx_ace.utils.date import get_current_time
+from edx_ace.utils.signals import send_ace_message_sent_signal
 
 LOG = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ def deliver(channel, rendered_message, message):
             message.report(f'{channel_type}_delivery_retried', num_seconds)
         else:
             message.report(f'{channel_type}_delivery_succeeded', True)
-            ACE_MESSAGE_SENT.send(sender=channel, message=message)
+            send_ace_message_sent_signal(channel, message)
             return
 
     delivery_expired_report = f'{channel_type}_delivery_expired'

--- a/edx_ace/tests/utils/test_signals.py
+++ b/edx_ace/tests/utils/test_signals.py
@@ -1,4 +1,8 @@
+"""
+Tests for the utils/signals module.
+"""
 from django.test import TestCase
+
 from edx_ace.utils.signals import make_serializable_object
 
 

--- a/edx_ace/tests/utils/test_signals.py
+++ b/edx_ace/tests/utils/test_signals.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from edx_ace.utils.signals import make_serializable_object
 
+
 class TestMakeSerializableObject(TestCase):
     def test_primitive_types(self):
         self.assertEqual(make_serializable_object(42), 42)

--- a/edx_ace/tests/utils/test_signals.py
+++ b/edx_ace/tests/utils/test_signals.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from edx_ace.utils.signals import make_serializable_object
+
+class TestMakeSerializableObject(TestCase):
+    def test_primitive_types(self):
+        self.assertEqual(make_serializable_object(42), 42)
+        self.assertEqual(make_serializable_object(3.14), 3.14)
+        self.assertEqual(make_serializable_object("string"), "string")
+        self.assertEqual(make_serializable_object(True), True)
+        self.assertEqual(make_serializable_object(None), None)
+
+    def test_dict(self):
+        input_dict = {
+            "int": 1,
+            "float": 2.0,
+            "str": "test",
+            "bool": False,
+            "none": None,
+            "list": [1, 2, 3],
+            "nested_dict": {"key": "value"}
+        }
+        self.assertEqual(make_serializable_object(input_dict), input_dict)
+
+    def test_list(self):
+        input_list = [1, 2.0, "test", False, None, [1, 2, 3], {"key": "value"}]
+        self.assertEqual(make_serializable_object(input_list), input_list)
+
+    def test_non_serializable(self):
+        class NonSerializable:
+            pass
+
+        obj = NonSerializable()
+        self.assertEqual(make_serializable_object(obj), str(obj))
+
+    def test_non_serializable_list(self):
+        class NonSerializable:
+            pass
+
+        obj = NonSerializable()
+        obj2 = NonSerializable()
+        obj_list = [obj, obj2]
+        self.assertEqual(make_serializable_object(obj_list), [str(obj), str(obj2)])

--- a/edx_ace/utils/signals.py
+++ b/edx_ace/utils/signals.py
@@ -1,0 +1,43 @@
+"""
+Utils for signals.
+"""
+from edx_ace.signals import ACE_MESSAGE_SENT
+
+
+def make_serializable_object(obj):
+    """
+    Takes a dictionary/list and returns a dictionary/list with all the values converted
+    to JSON serializable objects.
+    """
+    if isinstance(obj, (int, float, str, bool)) or obj is None:
+        return obj
+    elif isinstance(obj, dict):
+        return {key: make_serializable_object(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        return [make_serializable_object(element) for element in obj]
+    return str(obj)
+
+
+def send_ace_message_sent_signal(channel, message):
+    """
+    Creates dictionary from message, makes it JSON serializable and
+    sends the ACE_MESSAGE_SENT signal.
+    """
+    try:
+        channel_name = channel.__class__.__name__
+    except AttributeError:
+        channel_name = 'Other'
+    data = {
+        'name': message.name,
+        'app_label': message.app_label,
+        'recipient': {
+            'email': getattr(message.recipient, 'email_address', ''),
+            'user_id': getattr(message.recipient, 'lms_user_id', ''),
+        },
+        'channel': channel_name,
+        'context': message.context,
+        'options': message.options,
+        'uuid': str(message.uuid),
+        'send_uuid': str(message.send_uuid),
+    }
+    ACE_MESSAGE_SENT.send(sender=channel, message=make_serializable_object(data))

--- a/edx_ace/utils/signals.py
+++ b/edx_ace/utils/signals.py
@@ -16,7 +16,7 @@ def make_serializable_object(obj):
             return {key: make_serializable_object(value) for key, value in obj.items()}
         elif isinstance(obj, list):
             return [make_serializable_object(element) for element in obj]
-    except:        # pylint: disable=bare-except
+    except Exception:    # pylint: disable=broad-except
         pass
     return str(obj)
 

--- a/edx_ace/utils/signals.py
+++ b/edx_ace/utils/signals.py
@@ -9,12 +9,15 @@ def make_serializable_object(obj):
     Takes a dictionary/list and returns a dictionary/list with all the values converted
     to JSON serializable objects.
     """
-    if isinstance(obj, (int, float, str, bool)) or obj is None:
-        return obj
-    elif isinstance(obj, dict):
-        return {key: make_serializable_object(value) for key, value in obj.items()}
-    elif isinstance(obj, list):
-        return [make_serializable_object(element) for element in obj]
+    try:
+        if isinstance(obj, (int, float, str, bool)) or obj is None:
+            return obj
+        elif isinstance(obj, dict):
+            return {key: make_serializable_object(value) for key, value in obj.items()}
+        elif isinstance(obj, list):
+            return [make_serializable_object(element) for element in obj]
+    except:        # pylint: disable=bare-except
+        pass
     return str(obj)
 
 


### PR DESCRIPTION
Replaced message object with serializable dictionary when sending ACE_MESSAGE_SENT signal. It will avoid any exception due to non JSON serializable instance 

JIRA: [INF-1566](https://2u-internal.atlassian.net/browse/INF-1566)