### PR TITLE
chore: updated python version on pypi publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install Dependencies
         run: pip install setuptools wheel


### PR DESCRIPTION
Updated github workflow (pypi publish) version to python 3.11 