### PR TITLE
fix: Removed edx-braze-client from base.in

### DIFF
--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '1.13.0'
+__version__ = '1.14.0'
 
 
 __all__ = [

--- a/edx_ace/tests/utils/test_braze_utils.py
+++ b/edx_ace/tests/utils/test_braze_utils.py
@@ -28,7 +28,7 @@ class TestBrazeClient(TestCase):
         self.assertEqual(result, None)
         mock_braze_client.assert_not_called()
 
-    @override_settings(ACE_CHANNEL_BRAZE_API_KEY=API_KEY)
+    @override_settings(ACE_CHANNEL_BRAZE_PUSH_API_KEY=API_KEY)
     @patch('edx_ace.utils.braze.BrazeClient')
     def test_braze_url_not_configured(self, mock_braze_client):
         """
@@ -48,7 +48,7 @@ class TestBrazeClient(TestCase):
         self.assertEqual(result, None)
         mock_braze_client.assert_not_called()
 
-    @override_settings(ACE_CHANNEL_BRAZE_REST_ENDPOINT=API_KEY, ACE_CHANNEL_BRAZE_API_KEY=API_KEY)
+    @override_settings(ACE_CHANNEL_BRAZE_REST_ENDPOINT=API_KEY, ACE_CHANNEL_BRAZE_PUSH_API_KEY=API_KEY)
     @patch('edx_ace.utils.braze.BrazeClient', return_value=True)
     def test_success(self, mock_braze_client):
         """

--- a/edx_ace/utils/braze.py
+++ b/edx_ace/utils/braze.py
@@ -14,7 +14,7 @@ def get_braze_client():
     if not BrazeClient:
         return None
 
-    braze_api_key = getattr(settings, 'ACE_CHANNEL_BRAZE_API_KEY', None)
+    braze_api_key = getattr(settings, 'ACE_CHANNEL_BRAZE_PUSH_API_KEY', None)
     braze_api_url = getattr(settings, 'ACE_CHANNEL_BRAZE_REST_ENDPOINT', None)
 
     if not braze_api_key or not braze_api_url:

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,6 @@ Django>=2.2                       # Web application framework
 python-dateutil                   # Python Date Utilities
 attrs>=17.2.0                     # Attributes without boilerplate
 sailthru-client==2.2.3
-edx-braze-client==1.0.2
 six
 stevedore>=1.10.0
 edx-django-utils>=5.14.2

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -10,3 +10,4 @@ tox                       # virtualenv management for tests
 twine                     # Utility for PyPI package uploads
 wheel                     # For generation of wheels for PyPI
 backports.zoneinfo; python_version<'3.9'  # Needed for Python 3.12 compatibility
+edx-braze-client==1.0.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ django-waffle==4.2.0
 docutils==0.21.2
     # via readme-renderer
 edx-braze-client==1.0.2
-    # via -r requirements/base.in
+    # via -r requirements/dev.in
 edx-django-utils==7.4.0
     # via
     #   -r requirements/base.in

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -8,3 +8,4 @@ readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
 twine
 backports.zoneinfo; python_version<'3.9'  # Needed for Python 3.12 compatibility
+edx-braze-client==1.0.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -59,7 +59,7 @@ docutils==0.21.2
     #   restructuredtext-lint
     #   sphinx
 edx-braze-client==1.0.2
-    # via -r requirements/base.in
+    # via -r requirements/doc.in
 edx-django-utils==7.4.0
     # via
     #   -r requirements/base.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,3 +11,4 @@ pudb                      # For easier test debugging
 hypothesis[pytz]          # For property-based testing
 hypothesis-pytest
 backports.zoneinfo; python_version<'3.9'  # Needed for Python 3.12 compatibility
+edx-braze-client==1.0.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -45,7 +45,7 @@ django-push-notifications==3.2.1
 django-waffle==4.2.0
     # via edx-django-utils
 edx-braze-client==1.0.2
-    # via -r requirements/base.in
+    # via -r requirements/test.in
 edx-django-utils==7.4.0
     # via
     #   -r requirements/base.in

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,8 @@ setup(
     install_requires=load_requirements('requirements/base.in'),
     extras_require={
         'sailthru':  ["sailthru-client>2.2,<2.3"],
-        'push_notifications':  ["django-push-notifications[FCM]"]
+        'push_notifications':  ["django-push-notifications[FCM]"],
+        'braze_push': ['edx-braze-client==1.0.2']
     },
     license="AGPL 3.0",
     zip_safe=False,


### PR DESCRIPTION
**Description:** 
 Removed edx-braze-client from base.in. Makes edx-braze-client a dependency for dev and test, but no longer for base.in. This may allow us to remove edx-braze-client in edx-platform. 
 To have more context on this solution you can look to this `[PR](https://github.com/openedx/edx-enterprise/pull/2352)`. I have imported same logice from edx-enterprise to edx-ace.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Create a new release (can be done here https://github.com/edx/edx-ace/releases)
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
