### PR TITLE
Add jawad-khan as maintainer in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,6 +13,6 @@ metadata:
   annotations:
     openedx.org/arch-interest-groups: ""
 spec:
-  owner: group:2u-infinity
+  owner: user:jawad-khan
   type: 'library'
   lifecycle: 'production'

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ allowlist_externals =
     make
     rm
 deps = 
-    setuptools
+    setuptools<82
     wheel
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/doc.txt


### PR DESCRIPTION
Per OEP-55, update the owner field to reflect the new maintainer.

**Description:**
Add jawad-khan as maintainer in catalog-info.yaml as per discussion in thread: https://discuss.openedx.org/t/cc-rights-expansion-jawad-khan/18361/6.