### PR TITLE
chore: drop Django 4.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.12']
-        toxenv: [quality, docs, django42, django52]
+        toxenv: [quality, docs, django52]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.12']
-        toxenv: [quality, docs, django52]
+        toxenv: [quality, docs, py312-django52]
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.12' && matrix.toxenv=='django52'
+      if: matrix.python-version == '3.12' && matrix.toxenv=='py312-django52'
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 **********
 
+* Dropped Django 4.2 support.
+
 [1.15.0] - 2025-04-25
 ---------------------
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Core requirements for using this application
 
 -c constraints.txt
-Django>=2.2                       # Web application framework
+Django>=5.2,<5.3                  # Web application framework
 python-dateutil                   # Python Date Utilities
 attrs>=17.2.0                     # Attributes without boilerplate
 sailthru-client==2.2.3

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,6 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{312}-django{42, 52}, docs, quality
+envlist = py{312}-django{52}, docs, quality
 
 [testenv]
 deps = 
     setuptools
-    django42: Django>=4.2,<4.3
     django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands = 
@@ -35,7 +34,7 @@ setenv =
     PYTHONPATH = {toxinidir}/:{toxinidir}/edx_ace
 deps = 
     setuptools
-    quality: Django>=4.2,<4.3
+    Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/quality.txt
 allowlist_externals = 


### PR DESCRIPTION
**Description:** Dropped Django 4.2 support. Removed Django 4.2 from CI matrix, tox environments, and setup.py classifiers.

Issue: https://github.com/openedx/public-engineering/issues/458

**JIRA:** N/A

**Dependencies:** N/A

**Merge deadline:** N/A

**Installation instructions:** N/A

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Create a new release (can be done here https://github.com/edx/edx-ace/releases)
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)